### PR TITLE
fix: Fixed conversion logic between Arrow and Protobuf

### DIFF
--- a/crates/arkflow-plugin/src/processor/protobuf.rs
+++ b/crates/arkflow-plugin/src/processor/protobuf.rs
@@ -359,32 +359,8 @@ impl Processor for ProtobufProcessor {
             ToType::ArrowToProtobuf => {
                 // Convert Arrow format to Protobuf.
                 let proto_data = self.arrow_to_protobuf(&msg)?;
-                let schema = msg.schema();
-                let fields_vec: Vec<Arc<Field>> = schema.fields().iter().cloned().collect();
-                let mut fields = Vec::new();
-                for field in fields_vec {
-                    fields.push(field);
-                }
 
-                fields.push(Arc::new(Field::new(
-                    DEFAULT_BINARY_VALUE_FIELD,
-                    DataType::Binary,
-                    false,
-                )));
-                let new_schema = Arc::new(Schema::new(fields));
-
-                let mut columns: Vec<ArrayRef> = Vec::new();
-                for i in 0..schema.fields().len() {
-                    columns.push(msg.column(i).clone());
-                }
-                let binary_data: Vec<&[u8]> = proto_data.iter().map(|v| v.as_slice()).collect();
-                columns.push(Arc::new(BinaryArray::from(binary_data)));
-
-                let new_msg = RecordBatch::try_new(new_schema, columns).map_err(|e| {
-                    Error::Process(format!("Creating an Arrow record batch failed: {}", e))
-                })?;
-
-                Ok(vec![MessageBatch::new_arrow(new_msg)])
+                Ok(vec![msg.new_binary_with_origin(proto_data)?])
             }
             ToType::ProtobufToArrow(ref c) => {
                 if msg.is_empty() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the data conversion process to preserve original `MessageBatch` inputs while applying an improved transformation.
	- Introduced a new method for creating `MessageBatch` that retains the original structure while adding binary data.
	- Simplified the `process` method in the `ArrowToJsonProcessor` for a more concise and streamlined implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->