### PR TITLE
fix(udf): Functions with the same name are not allowed to be injected

### DIFF
--- a/crates/arkflow-plugin/src/processor/udf/aggregate_udf.rs
+++ b/crates/arkflow-plugin/src/processor/udf/aggregate_udf.rs
@@ -14,11 +14,12 @@
 use arkflow_core::Error;
 use datafusion::execution::FunctionRegistry;
 use datafusion::logical_expr::AggregateUDF;
+use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use tracing::debug;
 
 lazy_static::lazy_static! {
-   static ref UDFS: RwLock<Vec<Arc<AggregateUDF>>> = RwLock::new(Vec::new());
+   static ref UDFS: RwLock<HashMap<String,Arc<AggregateUDF>>> = RwLock::new(HashMap::new());
 }
 
 /// Register a new aggregate UDF (User Defined Function).
@@ -30,7 +31,11 @@ lazy_static::lazy_static! {
 /// * `udf` - The AggregateUDF instance to register.
 pub fn register(udf: AggregateUDF) {
     let mut udfs = UDFS.write().expect("Failed to acquire write lock for UDFS");
-    udfs.push(Arc::new(udf));
+    let name = udf.name();
+    if udfs.contains_key(name) {
+        panic!("Aggregate UDF with name '{}' already registered", name);
+    };
+    udfs.insert(name.to_string(), Arc::new(udf));
 }
 
 pub(crate) fn init<T: FunctionRegistry>(registry: &mut T) -> Result<(), Error> {
@@ -39,7 +44,7 @@ pub(crate) fn init<T: FunctionRegistry>(registry: &mut T) -> Result<(), Error> {
         .expect("Failed to acquire read lock for aggregate UDFS");
     aggregate_udfs
         .iter()
-        .try_for_each(|udf| {
+        .try_for_each(|(_, udf)| {
             let existing_udf = registry.register_udaf(Arc::clone(udf))?;
             if let Some(existing_udf) = existing_udf {
                 debug!("Overwrite existing aggregate UDF: {}", existing_udf.name());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate user-defined function (UDF) registrations by enforcing unique names for aggregate, scalar, and window UDFs.

- **Refactor**
  - Improved internal handling of UDFs for better reliability and consistency during registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->