### PR TITLE
fix: Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,9 @@ FROM debian:bookworm-slim as arkflow
 
 WORKDIR /app
 
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y libsqlite3-0 && rm -rf /var/lib/apt/lists/*
+
 # Copy compiled binary from builder stage
 COPY --from=builder /app/target/release/arkflow /app/arkflow
 


### PR DESCRIPTION
Fix Dockerfile issue: missing libsqlite3.so.0 causing container startup failure



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved Docker image reliability by explicitly installing required system libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->