### PR TITLE
chore(build-release): Enable Link-Time Optimization (LTO) and codegen-units = 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,3 +69,8 @@ arkflow-core = { path = "crates/arkflow-core", version = "0.2.0-rc2" }
 arkflow-plugin = { path = "crates/arkflow-plugin", version = "0.2.0-rc2" }
 tempfile = "3.19.1"
 mockall = "0.12"
+
+
+[profile.release]
+codegen-units = 1
+lto = true


### PR DESCRIPTION
close #285 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated release build settings to improve optimization and performance for release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->