### PR TITLE
Add MySQL output plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,6 @@ dependencies = [
  "humantime",
  "lazy_static",
  "mockall",
- "mysql_async 0.36.0",
  "prost-reflect",
  "prost-types",
  "protobuf",
@@ -219,6 +218,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "spiceai_duckdb_fork",
+ "sqlx",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -1188,6 +1188,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64ct"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+
+[[package]]
 name = "bb8"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,6 +1280,9 @@ name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitvec"
@@ -1621,6 +1630,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "configure_me"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1647,6 +1665,12 @@ dependencies = [
  "unicode-segmentation",
  "void",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-random"
@@ -1708,6 +1732,21 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
@@ -2409,7 +2448,7 @@ dependencies = [
  "futures",
  "geo-types",
  "itertools 0.14.0",
- "mysql_async 0.35.1",
+ "mysql_async",
  "native-tls",
  "num-bigint",
  "pem",
@@ -2435,6 +2474,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2450,6 +2500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -2464,6 +2515,12 @@ dependencies = [
  "quote",
  "syn 2.0.100",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "downcast"
@@ -2500,6 +2557,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -2536,6 +2596,28 @@ checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2728,6 +2810,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2926,6 +3019,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.2",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2942,6 +3044,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -3508,6 +3619,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lazycell"
@@ -3710,15 +3824,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f8cc7106155f10bdf99a6f379688f543ad6596a415375b36a59a054ceda1198"
-dependencies = [
- "hashbrown 0.15.2",
-]
-
-[[package]]
 name = "lru-cache"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3901,43 +4006,13 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "keyed_priority_queue",
- "lru 0.12.5",
- "mysql_common 0.34.1",
+ "lru",
+ "mysql_common",
  "native-tls",
  "pem",
  "percent-encoding",
  "pin-project",
  "rand 0.8.5",
- "serde",
- "serde_json",
- "socket2",
- "thiserror 2.0.12",
- "tokio",
- "tokio-native-tls",
- "tokio-util",
- "twox-hash 2.1.0",
- "url",
-]
-
-[[package]]
-name = "mysql_async"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d0d6385c37d331a4502565a1be2a06b23d4ada08ee5177c6374272cd8980a6"
-dependencies = [
- "bytes",
- "crossbeam-queue",
- "flate2",
- "futures-core",
- "futures-sink",
- "futures-util",
- "keyed_priority_queue",
- "lru 0.14.0",
- "mysql_common 0.35.3",
- "native-tls",
- "pem",
- "percent-encoding",
- "rand 0.9.0",
  "serde",
  "serde_json",
  "socket2",
@@ -3982,33 +4057,6 @@ dependencies = [
  "time",
  "uuid",
  "zstd",
-]
-
-[[package]]
-name = "mysql_common"
-version = "0.35.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4351dce0b6634a60d6f1f40fae5cfcfe0f6c6a4a1e87e8da7babe4c37c522460"
-dependencies = [
- "base64 0.22.1",
- "bitflags 2.9.0",
- "btoi",
- "byteorder",
- "bytes",
- "crc32fast",
- "flate2",
- "getrandom 0.3.2",
- "mysql-common-derive",
- "num-bigint",
- "num-traits",
- "regex",
- "saturating",
- "serde",
- "serde_json",
- "sha1",
- "sha2",
- "thiserror 2.0.12",
- "uuid",
 ]
 
 [[package]]
@@ -4079,6 +4127,23 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
 ]
 
 [[package]]
@@ -4289,6 +4354,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4388,6 +4459,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4472,6 +4552,27 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -5203,6 +5304,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e33e4fb37ba46888052c763e4ec2acfedd8f00f62897b630cadb6298b833675e"
 
 [[package]]
+name = "rsa"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rumqttc"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5229,7 +5350,7 @@ dependencies = [
  "bitflags 2.9.0",
  "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.9.1",
  "libsqlite3-sys",
  "smallvec",
 ]
@@ -5738,6 +5859,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5763,6 +5894,9 @@ name = "smallvec"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "snafu"
@@ -5811,7 +5945,7 @@ dependencies = [
  "cast",
  "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.9.1",
  "libduckdb-sys",
  "memchr",
  "num",
@@ -5829,6 +5963,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -5851,6 +5995,196 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3a85280daca669cfd3bcb68a337882a8bc57ec882f72c5d13a430613a738e"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f743f2a3cea30a58cd479013f75550e879009e3a02f616f18ca699335aa248c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.2",
+ "hashlink 0.10.0",
+ "indexmap 2.9.0",
+ "log",
+ "memchr",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4200e0fde19834956d4252347c12a083bdcb237d7a1a1446bffd8768417dce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ceaa29cade31beca7129b6beeb05737f44f82dbe2a9806ecea5a7093d00b7"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck 0.5.0",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.100",
+ "tempfile",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0afdd3aa7a629683c2d750c2df343025545087081ab5942593a5288855b1b7a7"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.9.0",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.12",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0bedbe1bbb5e2615ef347a5e9d8cd7680fb63e77d9dafc0f29be15e53f1ebe6"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.9.0",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.12",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c26083e9a520e8eb87a06b12347679b142dc2ea29e6e409f805644a7a979a5bc"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.12",
+ "tracing",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,7 @@ dependencies = [
  "humantime",
  "lazy_static",
  "mockall",
+ "mysql_async 0.36.0",
  "prost-reflect",
  "prost-types",
  "protobuf",
@@ -2408,7 +2409,7 @@ dependencies = [
  "futures",
  "geo-types",
  "itertools 0.14.0",
- "mysql_async",
+ "mysql_async 0.35.1",
  "native-tls",
  "num-bigint",
  "pem",
@@ -3709,6 +3710,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f8cc7106155f10bdf99a6f379688f543ad6596a415375b36a59a054ceda1198"
+dependencies = [
+ "hashbrown 0.15.2",
+]
+
+[[package]]
 name = "lru-cache"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3891,13 +3901,43 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "keyed_priority_queue",
- "lru",
- "mysql_common",
+ "lru 0.12.5",
+ "mysql_common 0.34.1",
  "native-tls",
  "pem",
  "percent-encoding",
  "pin-project",
  "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "socket2",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "twox-hash 2.1.0",
+ "url",
+]
+
+[[package]]
+name = "mysql_async"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20d0d6385c37d331a4502565a1be2a06b23d4ada08ee5177c6374272cd8980a6"
+dependencies = [
+ "bytes",
+ "crossbeam-queue",
+ "flate2",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "keyed_priority_queue",
+ "lru 0.14.0",
+ "mysql_common 0.35.3",
+ "native-tls",
+ "pem",
+ "percent-encoding",
+ "rand 0.9.0",
  "serde",
  "serde_json",
  "socket2",
@@ -3942,6 +3982,33 @@ dependencies = [
  "time",
  "uuid",
  "zstd",
+]
+
+[[package]]
+name = "mysql_common"
+version = "0.35.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4351dce0b6634a60d6f1f40fae5cfcfe0f6c6a4a1e87e8da7babe4c37c522460"
+dependencies = [
+ "base64 0.22.1",
+ "bitflags 2.9.0",
+ "btoi",
+ "byteorder",
+ "bytes",
+ "crc32fast",
+ "flate2",
+ "getrandom 0.3.2",
+ "mysql-common-derive",
+ "num-bigint",
+ "num-traits",
+ "regex",
+ "saturating",
+ "serde",
+ "serde_json",
+ "sha1",
+ "sha2",
+ "thiserror 2.0.12",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ flume = "=0.11"
 rumqttc = "0.24.0"
 
 # Sql
-mysql_async = { version = "0.36", features = ["native-tls-tls"] }
+sqlx = { version = "0.8", features = [ "mysql","postgres","runtime-tokio", "tls-native-tls" ] }
 
 # Kafka
 aws-msk-iam-sasl-signer = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,8 @@ colored = "3.0"
 flume = "=0.11"
 rumqttc = "0.24.0"
 
-
+# Sql
+mysql_async = { version = "0.36", features = ["native-tls-tls"] }
 
 # Kafka
 aws-msk-iam-sasl-signer = "1.0.0"

--- a/crates/arkflow-plugin/Cargo.toml
+++ b/crates/arkflow-plugin/Cargo.toml
@@ -55,7 +55,7 @@ sasl2-sys = { workspace = true }
 
 # arkflow
 arkflow-core = { workspace = true }
-mysql_async = { workspace = true }
+sqlx = { workspace= true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/arkflow-plugin/Cargo.toml
+++ b/crates/arkflow-plugin/Cargo.toml
@@ -55,6 +55,7 @@ sasl2-sys = { workspace = true }
 
 # arkflow
 arkflow-core = { workspace = true }
+mysql_async = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/arkflow-plugin/src/output/mod.rs
+++ b/crates/arkflow-plugin/src/output/mod.rs
@@ -22,6 +22,7 @@ pub mod drop;
 pub mod http;
 pub mod kafka;
 pub mod mqtt;
+pub mod sql;
 pub mod stdout;
 
 pub fn init() -> Result<(), Error> {
@@ -30,5 +31,6 @@ pub fn init() -> Result<(), Error> {
     kafka::init()?;
     mqtt::init()?;
     stdout::init()?;
+    sql::init()?;
     Ok(())
 }

--- a/crates/arkflow-plugin/src/output/sql.rs
+++ b/crates/arkflow-plugin/src/output/sql.rs
@@ -11,7 +11,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 use arkflow_core::output::{register_output_builder, Output, OutputBuilder};
 use arkflow_core::{Error, MessageBatch};
 
@@ -20,78 +19,205 @@ use datafusion::arrow::array::{
     Array, BooleanArray, Float64Array, Int64Array, StringArray, UInt64Array,
 };
 use datafusion::arrow::datatypes::DataType;
-
 use serde::{Deserialize, Serialize};
 use std::path::Path;
+use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
+use tracing::warn;
 
-use mysql_async::prelude::*;
-use mysql_async::{Conn, Opts, OptsBuilder, Pool, SslOpts, Statement};
+use sqlx::mysql::{MySqlConnectOptions, MySqlSslMode};
+use sqlx::postgres::{PgConnectOptions, PgSslMode};
+use sqlx::{Connection, MySqlConnection, PgConnection, QueryBuilder};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SqlOutputConfig {
-    /// SQL query statement
-    table_name: String,
-    #[serde(flatten)]
-    output_type: OutputType,
+#[derive(Debug, Clone)]
+pub enum SqlValue {
+    String(String),
+    Int64(i64),
+    UInt64(u64),
+    Float64(f64),
+    Boolean(bool),
+    Null,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct MysqlConfig {
-    name: Option<String>,
-    uri: String,
-    ssl: Option<MysqlSslConfig>,
+pub enum DatabaseType {
+    Mysql,
+    Postgres,
+    // Sqlite,
 }
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct MysqlSslConfig {
-    // Path to the root CA certificate file used to verify server's identity
-    root_cert: String,
+pub enum DatabaseConnection {
+    Mysql(MySqlConnection),
+    Postgres(PgConnection),
+    // Sqlite(SqliteConnection),
 }
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "output_type", rename_all = "snake_case")]
-enum OutputType {
-    Mysql(MysqlConfig),
-}
-
-#[derive(Debug)]
-enum DbConnection {
-    Mysql(Conn),
-}
-
-impl DbConnection {
-    pub async fn prepare_statement(&mut self, query: String) -> Result<Statement, Error> {
-        match self {
-            DbConnection::Mysql(conn) => conn
-                .prep(query)
-                .await
-                .map_err(|e| Error::Process(format!("Failed to prepare statement: {}", e))),
-        }
-    }
-
-    pub async fn execute_batch(
+impl DatabaseConnection {
+    /// Executes an INSERT query with the given columns and rows
+    /// Handles type conversion and proper escaping for different database types
+    /// Returns a Result indicating success or detailed error information
+    pub async fn execute_insert(
         &mut self,
-        stmt: &Statement,
-        params: Vec<Vec<String>>,
+        output_config: &SqlOutputConfig,
+        columns: Vec<String>,
+        rows: Vec<Vec<SqlValue>>,
     ) -> Result<(), Error> {
         match self {
-            DbConnection::Mysql(conn) => conn
-                .exec_batch(stmt, params)
-                .await
-                .map_err(|e| Error::Process(format!("Failed to execute prepared stmt: {}", e))),
+            DatabaseConnection::Mysql(conn) => {
+                let mut query_builder = QueryBuilder::<sqlx::MySql>::new(format!(
+                    "INSERT INTO {} ({})",
+                    output_config.table_name,
+                    columns
+                        .iter()
+                        .map(|c| format!("`{}`", c))
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                ));
+
+                query_builder.push_values(rows, |mut b, row| {
+                    for value in row {
+                        match value {
+                            SqlValue::String(s) => b.push_bind(s),
+                            SqlValue::Int64(i) => b.push_bind(i),
+                            SqlValue::UInt64(u) => b.push_bind(u),
+                            SqlValue::Float64(f) => b.push_bind(f),
+                            SqlValue::Boolean(bool) => b.push_bind(bool),
+                            SqlValue::Null => b.push_bind(None::<String>),
+                        };
+                    }
+                });
+
+                let query = query_builder.build();
+                query
+                    .execute(conn)
+                    .await
+                    .map_err(|e| Error::Process(format!("Failed to execute MySQL query: {}", e)))?;
+
+                Ok(())
+            }
+            DatabaseConnection::Postgres(conn) => {
+                let mut query_builder = QueryBuilder::<sqlx::Postgres>::new(format!(
+                    "INSERT INTO {} ({})",
+                    output_config.table_name,
+                    columns
+                        .iter()
+                        .map(|c| format!("\"{}\"", c))
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                ));
+                query_builder.push_values(rows, |mut b, row| {
+                    for value in row {
+                        match value {
+                            SqlValue::String(s) => b.push_bind(s),
+                            SqlValue::Int64(i) => b.push_bind(i),
+                            SqlValue::UInt64(u) => b.push_bind(u as i64),
+                            SqlValue::Float64(f) => b.push_bind(f),
+                            SqlValue::Boolean(bool) => b.push_bind(bool),
+                            SqlValue::Null => b.push_bind(None::<String>),
+                        };
+                    }
+                });
+
+                let query = query_builder.build();
+                query.execute(conn).await.map_err(|e| {
+                    Error::Process(format!("Failed to execute PostgresSQL query: {}", e))
+                })?;
+
+                Ok(())
+            }
         }
     }
+}
 
+/// Configuration for SQL output
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct SqlOutputConfig {
+    /// SQL query statement
+    output_type: DatabaseType,
+    table_name: String,
+    uri: String,
+    ssl: Option<SslConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SslConfig {
+    ssl_mode: String,
+    root_cert: Option<String>,
+    client_cert: Option<String>,
+    client_key: Option<String>,
+}
+impl SslConfig {
+    pub async fn generate_mysql_ssl_opts(
+        &self,
+        output_config: &SqlOutputConfig,
+    ) -> Result<MySqlConnectOptions, Error> {
+        let ssl_mode = match self.ssl_mode.to_lowercase().as_str() {
+            "disable" => MySqlSslMode::Disabled,
+            "prefer" => MySqlSslMode::Preferred,
+            "require" => MySqlSslMode::Required,
+            "verify_ca" => MySqlSslMode::VerifyCa,
+            "verify_full" => MySqlSslMode::VerifyIdentity,
+            _ => return Err(Error::Config("Invalid SSL mode".to_string())),
+        };
+        let mut opts = MySqlConnectOptions::from_str(&output_config.uri)
+            .map_err(|e| Error::Config(format!("Invalid MySQL URI: {}", e)))?;
+        opts = opts.ssl_mode(ssl_mode);
+
+        if let Some(root_cert) = &self.root_cert {
+            opts = opts.ssl_ca(Path::new(root_cert));
+        }
+
+        if let Some(client_cert) = &self.client_cert {
+            if let Some(client_key) = &self.client_key {
+                opts = opts.ssl_client_cert(Path::new(client_cert));
+                opts = opts.ssl_client_key(Path::new(client_key));
+            } else {
+                warn!("Client certificate provided without private key - will be ignored");
+            }
+        } else if self.client_key.is_some() {
+            warn!("Client key provided without certificate - will be ignored");
+        }
+        Ok(opts)
+    }
+    async fn generate_postgres_ssl_opts(
+        &self,
+        output_config: &SqlOutputConfig,
+    ) -> Result<PgConnectOptions, Error> {
+        let ssl_mode = match self.ssl_mode.to_lowercase().as_str() {
+            "disable" => PgSslMode::Disable,
+            "prefer" => PgSslMode::Prefer,
+            "require" => PgSslMode::Require,
+            "verify_ca" => PgSslMode::VerifyCa,
+            "verify_full" => PgSslMode::VerifyFull,
+            _ => return Err(Error::Config("Invalid SSL mode".to_string())),
+        };
+        let mut opts = PgConnectOptions::from_str(&output_config.uri)
+            .map_err(|e| Error::Config(format!("Invalid PostgreSQL URI: {}", e)))?;
+        opts = opts.ssl_mode(ssl_mode);
+
+        if let Some(root_cert) = &self.root_cert {
+            opts = opts.ssl_root_cert(Path::new(root_cert));
+        }
+
+        if let Some(client_cert) = &self.client_cert {
+            if let Some(client_key) = &self.client_key {
+                opts = opts.ssl_client_cert(Path::new(client_cert));
+                opts = opts.ssl_client_key(Path::new(client_key));
+            } else {
+                warn!("Client certificate provided without private key - will be ignored");
+            }
+        } else if self.client_key.is_some() {
+            warn!("Client key provided without certificate - will be ignored");
+        }
+        Ok(opts)
+    }
 }
 
 pub struct SqlOutput {
     sql_config: SqlOutputConfig,
-    db_connection: Arc<Mutex<Option<DbConnection>>>,
     connected: std::sync::atomic::AtomicBool,
-    prepared_stmt: Arc<Mutex<Option<Statement>>>,
+    conn_lock: Arc<Mutex<Option<DatabaseConnection>>>,
     cancellation_token: CancellationToken,
 }
 
@@ -101,9 +227,8 @@ impl SqlOutput {
 
         Ok(Self {
             sql_config,
-            db_connection: Arc::new(Mutex::new(None)),
             connected: std::sync::atomic::AtomicBool::new(false),
-            prepared_stmt: Arc::new(Mutex::new(None)),
+            conn_lock: Arc::new(Mutex::new(None)),
             cancellation_token,
         })
     }
@@ -116,20 +241,20 @@ impl Output for SqlOutput {
         }
 
         let conn = self.init_connect().await?;
-        let mut guard = self.db_connection.lock().await;
-        *guard = Some(conn);
-
+        let mut conn_guard = self.conn_lock.lock().await;
+        *conn_guard = Some(conn);
         self.connected
             .store(true, std::sync::atomic::Ordering::SeqCst);
+
         Ok(())
     }
-
     async fn write(&self, msg: MessageBatch) -> Result<(), Error> {
-        let mut guard = self.db_connection.lock().await;
-        let conn = guard.as_mut().expect("not connected");
+        let mut conn_guard = self.conn_lock.lock().await;
+        let conn = conn_guard
+            .as_mut()
+            .ok_or_else(|| Error::Process("Database connection is not initialized".to_string()))?;
 
         self.insert_row(conn, &msg).await?;
-
         Ok(())
     }
 
@@ -141,65 +266,44 @@ impl Output for SqlOutput {
 impl SqlOutput {
     /// Initialize a new DB connection.  
     /// If `ssl` is configured, apply root certificates to the SSL options.
-    async fn init_connect(&self) -> Result<DbConnection, Error> {
-        match self.sql_config.output_type {
-            OutputType::Mysql(ref c) => {
-                let database_url = c.uri.clone();
-
-                let base_opts = Opts::from_url(&database_url)
-                    .map_err(|e| Error::Config(format!("Invalid MySQL URI: {}", e)))?;
-
-                // Configure SSL/TLS if ssl configuration is provided
-                // This enables secure connections with certificate validation
-                let opts = if let Some(ref ssl_conf) = c.ssl {
-                    let cert_path = Path::new(&ssl_conf.root_cert).to_path_buf();
-                    let ssl_opts = SslOpts::default().with_root_certs(vec![cert_path.into()]);
-                    OptsBuilder::from_opts(base_opts).ssl_opts(ssl_opts)
-                } else {
-                    OptsBuilder::from_opts(base_opts)
-                };
-
-                let pool = Pool::new(opts);
-                let conn = pool
-                    .get_conn()
-                    .await
-                    .map_err(|e| Error::Config(format!("Failed to connect to MySQL: {}", e)))?;
-                Ok(DbConnection::Mysql(conn))
-            }
-        }
+    async fn init_connect(&self) -> Result<DatabaseConnection, Error> {
+        let conn = match self.sql_config.output_type {
+            DatabaseType::Mysql => self.generate_mysql_conn().await?,
+            DatabaseType::Postgres => self.generate_postgres_conn().await?,
+        };
+        Ok(conn)
     }
-    // insert_row implementation
-    async fn insert_row(&self, conn: &mut DbConnection, msg: &MessageBatch) -> Result<(), Error> {
+    /// Processes a batch of Arrow data and inserts it into the database
+    /// 1. Extracts schema and column names
+    /// 2. Converts each row to SQL-compatible values
+    /// 3. Executes the insert query with proper batching
+    async fn insert_row(
+        &self,
+        conn: &mut DatabaseConnection,
+        msg: &MessageBatch,
+    ) -> Result<(), Error> {
         let schema = msg.schema();
         let num_rows = msg.len();
         let num_columns = schema.fields().len();
         let columns: Vec<String> = (0..num_columns)
             .map(|i| schema.field(i).name().clone())
             .collect();
-        let stmt: Statement = {
-            let mut guard = self.prepared_stmt.lock().await;
-            if guard.is_none() {
-                let query = self.generate_insert_query(&columns, num_columns).await;
-                let prepared = conn.prepare_statement(query).await?;
-                *guard = Some(prepared.clone());
-                prepared
-            } else {
-                guard.as_ref().unwrap().clone()
-            }
-        };
 
-        let mut batch_params = Vec::with_capacity(num_rows);
+        let mut rows = Vec::with_capacity(num_columns * num_rows);
         for row_index in 0..num_rows {
-            let mut row = Vec::with_capacity(num_columns);
             for col_index in 0..num_columns {
                 let column = msg.column(col_index);
-                let value = self.matching_data_type(column, row_index).await?;
-                row.push(value);
-            }
-            batch_params.push(row);
-        }
-        conn.execute_batch(&stmt, batch_params).await?;
 
+                let value = self.matching_data_type(column, row_index).await?;
+                rows.push(value);
+            }
+        }
+        let rows: Vec<Vec<SqlValue>> = rows
+            .chunks(num_columns)
+            .map(|chunk| chunk.to_vec())
+            .collect();
+
+        conn.execute_insert(&self.sql_config, columns, rows).await?;
         Ok(())
     }
     // Convert Arrow data types to SQL-compatible string representation
@@ -207,32 +311,48 @@ impl SqlOutput {
         &self,
         column: &dyn Array,
         row_index: usize,
-    ) -> Result<String, Error> {
+    ) -> Result<SqlValue, Error> {
         // Determine the data type of the column and convert to appropriate SQL format
         let column_type = column.data_type();
         match column_type {
             DataType::Utf8 => {
                 let utf8_array = column.as_any().downcast_ref::<StringArray>().unwrap();
-                Ok(format!("{}", utf8_array.value(row_index)))
+                if utf8_array.is_null(row_index) {
+                    Ok(SqlValue::Null)
+                } else {
+                    Ok(SqlValue::String(utf8_array.value(row_index).to_string()))
+                }
             }
             DataType::Int64 => {
                 let int_array = column.as_any().downcast_ref::<Int64Array>().unwrap();
-                Ok(int_array.value(row_index).to_string())
+                if int_array.is_null(row_index) {
+                    Ok(SqlValue::Null)
+                } else {
+                    Ok(SqlValue::Int64(int_array.value(row_index)))
+                }
             }
             DataType::UInt64 => {
                 let uint_array = column.as_any().downcast_ref::<UInt64Array>().unwrap();
-                Ok(uint_array.value(row_index).to_string())
+                if uint_array.is_null(row_index) {
+                    Ok(SqlValue::Null)
+                } else {
+                    Ok(SqlValue::UInt64(uint_array.value(row_index)))
+                }
             }
             DataType::Float64 => {
                 let float_array = column.as_any().downcast_ref::<Float64Array>().unwrap();
-                Ok(float_array.value(row_index).to_string())
+                if float_array.is_null(row_index) {
+                    Ok(SqlValue::Null)
+                } else {
+                    Ok(SqlValue::Float64(float_array.value(row_index)))
+                }
             }
             DataType::Boolean => {
                 let bool_array = column.as_any().downcast_ref::<BooleanArray>().unwrap();
-                if bool_array.value(row_index) {
-                    Ok("true".to_string())
+                if bool_array.is_null(row_index) {
+                    Ok(SqlValue::Null)
                 } else {
-                    Ok("false".to_string())
+                    Ok(SqlValue::Boolean(bool_array.value(row_index)))
                 }
             }
             _ => Err(Error::Process(format!(
@@ -241,19 +361,33 @@ impl SqlOutput {
             ))),
         }
     }
-    async fn generate_insert_query(&self, columns: &Vec<String>, num_columns: usize) -> String {
-        let table_name = &self.sql_config.table_name;
-
-        let escaped_columns: Vec<String> = columns.iter().map(|col| format!("`{}`", col)).collect();
-        let placeholders = match self.sql_config.output_type {
-            OutputType::Mysql(_) => vec!["?"; num_columns].join(", "),
+    /// Generates MySQL SSL connection options based on configuration
+    /// Validates SSL mode and sets up certificates if provided
+    async fn generate_mysql_conn(&self) -> Result<DatabaseConnection, Error> {
+        let mysql_conn = if let Some(ssl) = &self.sql_config.ssl {
+            let opts = ssl.generate_mysql_ssl_opts(&self.sql_config).await?;
+            MySqlConnection::connect_with(&opts)
+                .await
+                .map_err(|e| Error::Config(format!("Failed to connect to MySQL with SSL: {}", e)))?
+        } else {
+            MySqlConnection::connect(&self.sql_config.uri)
+                .await
+                .map_err(|e| Error::Config(format!("Failed to connect to MySQL: {}", e)))?
         };
-        format!(
-            "INSERT INTO {} ({}) VALUES ({})",
-            table_name,
-            escaped_columns.join(", "),
-            placeholders
-        )
+        Ok(DatabaseConnection::Mysql(mysql_conn))
+    }
+    async fn generate_postgres_conn(&self) -> Result<DatabaseConnection, Error> {
+        let postgres_conn = if let Some(ssl) = &self.sql_config.ssl {
+            let opts = ssl.generate_postgres_ssl_opts(&self.sql_config).await?;
+            PgConnection::connect_with(&opts).await.map_err(|e| {
+                Error::Config(format!("Failed to connect to PostgreSQL with SSL: {}", e))
+            })?
+        } else {
+            PgConnection::connect(&self.sql_config.uri)
+                .await
+                .map_err(|e| Error::Config(format!("Failed to connect to PostgreSQL: {}", e)))?
+        };
+        Ok(DatabaseConnection::Postgres(postgres_conn))
     }
 }
 

--- a/crates/arkflow-plugin/src/output/sql.rs
+++ b/crates/arkflow-plugin/src/output/sql.rs
@@ -1,0 +1,260 @@
+/*
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+use arkflow_core::output::{register_output_builder, Output, OutputBuilder};
+use arkflow_core::{Error, MessageBatch};
+
+use async_trait::async_trait;
+use datafusion::arrow::array::{
+    Array, BooleanArray, Float64Array, Int64Array, StringArray, UInt64Array,
+};
+use datafusion::arrow::datatypes::DataType;
+
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+use mysql_async::prelude::*;
+use mysql_async::{Conn, Opts, OptsBuilder, Pool, SslOpts};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SqlOutputConfig {
+    /// SQL query statement
+    table_name: String,
+    #[serde(flatten)]
+    output_type: OutputType,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct MysqlConfig {
+    name: Option<String>,
+    uri: String,
+    ssl: Option<MysqlSslConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct MysqlSslConfig {
+    // Path to the root CA certificate file used to verify server's identity
+    root_cert: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "output_type", rename_all = "snake_case")]
+enum OutputType {
+    Mysql(MysqlConfig),
+}
+
+#[derive(Debug)]
+enum DbConnection {
+    Mysql(Conn),
+}
+
+impl DbConnection {
+    // Executes a SQL query without returning results
+    pub async fn execute_query(&mut self, query: &str) -> Result<(), Error> {
+        match self {
+            DbConnection::Mysql(conn) => conn
+                .query_drop(query)
+                .await
+                .map_err(|e| Error::Process(format!("Failed to execute query: {}", e))),
+        }
+    }
+    pub async fn begin_transaction(&mut self) -> Result<(), Error> {
+        match self {
+            DbConnection::Mysql(conn) => conn
+                .query_drop("BEGIN")
+                .await
+                .map_err(|e| Error::Process(format!("Failed to begin transaction: {}", e))),
+        }
+    }
+    pub async fn commit_transaction(&mut self) -> Result<(), Error> {
+        match self {
+            DbConnection::Mysql(conn) => conn
+                .query_drop("COMMIT")
+                .await
+                .map_err(|e| Error::Process(format!("Failed to commit transaction: {}", e))),
+        }
+    }
+}
+
+pub struct SqlOutput {
+    sql_config: SqlOutputConfig,
+    db_connection: Arc<Mutex<Option<DbConnection>>>,
+    connected: std::sync::atomic::AtomicBool,
+    cancellation_token: CancellationToken,
+}
+
+//수정할 생각 필요
+impl SqlOutput {
+    pub fn new(sql_config: SqlOutputConfig) -> Result<Self, Error> {
+        let cancellation_token = CancellationToken::new();
+
+        Ok(Self {
+            sql_config,
+            db_connection: Arc::new(Mutex::new(None)),
+            connected: std::sync::atomic::AtomicBool::new(false),
+            cancellation_token,
+        })
+    }
+}
+#[async_trait]
+impl Output for SqlOutput {
+    async fn connect(&self) -> Result<(), Error> {
+        if self.connected.load(std::sync::atomic::Ordering::SeqCst) {
+            return Ok(());
+        }
+
+        let conn = self.init_connect().await?;
+        let mut guard = self.db_connection.lock().await;
+        *guard = Some(conn);
+
+        self.connected
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn write(&self, msg: MessageBatch) -> Result<(), Error> {
+        let mut guard = self.db_connection.lock().await;
+        let conn = guard.as_mut().expect("not connected");
+
+        conn.begin_transaction().await?;
+        self.insert_row(conn, &msg).await?;
+        conn.commit_transaction().await?;
+
+        Ok(())
+    }
+
+    async fn close(&self) -> Result<(), Error> {
+        self.cancellation_token.cancel();
+        Ok(())
+    }
+}
+impl SqlOutput {
+    /// Initialize a new DB connection.  
+    /// If `ssl` is configured, apply root certificates to the SSL options.
+    async fn init_connect(&self) -> Result<DbConnection, Error> {
+        match self.sql_config.output_type {
+            OutputType::Mysql(ref c) => {
+                let database_url = c.uri.clone();
+
+                let base_opts = Opts::from_url(&database_url)
+                    .map_err(|e| Error::Config(format!("Invalid MySQL URI: {}", e)))?;
+
+                // Configure SSL/TLS if ssl configuration is provided
+                // This enables secure connections with certificate validation
+                let opts = if let Some(ref ssl_conf) = c.ssl {
+                    let cert_path = Path::new(&ssl_conf.root_cert).to_path_buf();
+                    let ssl_opts = SslOpts::default().with_root_certs(vec![cert_path.into()]);
+                    OptsBuilder::from_opts(base_opts).ssl_opts(ssl_opts)
+                } else {
+                    OptsBuilder::from_opts(base_opts)
+                };
+
+                let pool = Pool::new(opts);
+                let conn = pool
+                    .get_conn()
+                    .await
+                    .map_err(|e| Error::Config(format!("Failed to connect to MySQL: {}", e)))?;
+                Ok(DbConnection::Mysql(conn))
+            }
+        }
+    }
+    // insert_row implementation
+    async fn insert_row(&self, conn: &mut DbConnection, msg: &MessageBatch) -> Result<(), Error> {
+        let table_name = self.sql_config.table_name.clone();
+        let schema = msg.schema();
+        let num_rows = msg.len();
+        let num_columns = schema.fields().len();
+
+        for row_index in 0..num_rows {
+            let mut columns = Vec::new();
+            let mut values = Vec::new();
+
+            for col_index in 0..num_columns {
+                let field = schema.field(col_index);
+                let column_name = field.name();
+                columns.push(column_name.clone());
+
+                let column = msg.column(col_index);
+
+                let value = &self.matching_data_type(column, row_index).await;
+
+                values.push(format!("'{}'", value));
+            }
+            let query = format!(
+                "INSERT INTO {} ({}) VALUES ({})",
+                table_name,
+                columns.join(", "),
+                values.join(", ")
+            );
+
+            conn.execute_query(&query)
+                .await
+                .map_err(|e| Error::Process(format!("Failed to insert row: {}", e)))?;
+        }
+        Ok(())
+    }
+    // Convert Arrow data types to SQL-compatible string representation
+    async fn matching_data_type(&self, column: &dyn Array, row_index: usize) -> String {
+        // Determine the data type of the column and convert to appropriate SQL format
+        let column_type = column.data_type();
+        match column_type {
+            DataType::Utf8 => {
+                let utf8_array = column.as_any().downcast_ref::<StringArray>().unwrap();
+                format!("{}", utf8_array.value(row_index))
+            }
+            DataType::Int64 => {
+                let int_array = column.as_any().downcast_ref::<Int64Array>().unwrap();
+                int_array.value(row_index).to_string()
+            }
+            DataType::UInt64 => {
+                let uint_array = column.as_any().downcast_ref::<UInt64Array>().unwrap();
+                uint_array.value(row_index).to_string()
+            }
+            DataType::Float64 => {
+                let float_array = column.as_any().downcast_ref::<Float64Array>().unwrap();
+                float_array.value(row_index).to_string()
+            }
+            DataType::Boolean => {
+                let bool_array = column.as_any().downcast_ref::<BooleanArray>().unwrap();
+                if bool_array.value(row_index) {
+                    "TRUE".to_string()
+                } else {
+                    "FALSE".to_string()
+                }
+            }
+            DataType::Null => "NULL".to_string(),
+            _ => "NULL".to_string(),
+        }
+    }
+}
+
+pub(crate) struct SqlOutputBuilder;
+impl OutputBuilder for SqlOutputBuilder {
+    fn build(&self, config: &Option<serde_json::Value>) -> Result<Arc<dyn Output>, Error> {
+        if config.is_none() {
+            return Err(Error::Config(
+                "SQL output configuration is missing".to_string(),
+            ));
+        }
+
+        let config: SqlOutputConfig = serde_json::from_value(config.clone().unwrap())?;
+        Ok(Arc::new(SqlOutput::new(config)?))
+    }
+}
+pub fn init() -> Result<(), Error> {
+    register_output_builder("sql", Arc::new(SqlOutputBuilder))
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,9 @@ FROM debian:bookworm-slim as arkflow
 
 WORKDIR /app
 
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y libsqlite3-0 && rm -rf /var/lib/apt/lists/*
+
 # Copy compiled binary from builder stage
 COPY --from=builder /app/target/release/arkflow /app/arkflow
 

--- a/examples/sql_output_example.yaml
+++ b/examples/sql_output_example.yaml
@@ -1,0 +1,24 @@
+logging:
+  level: info
+streams:
+  - input:
+      type: "generate"
+      context: '{ "timestamp": 1625000000000, "value": 10, "sensor": "temp_1" }'
+      interval: 1s
+      batch_size: 10
+
+    pipeline:
+      thread_num: 4
+      processors:
+        - type: "json_to_arrow"
+        - type: "sql"
+          query: "SELECT * FROM flow WHERE value >= 10"
+
+    output:
+      type: "sql"
+      output_type: "mysql"
+      uri: "mysql://root:1234@localhost:3306/arkflow"
+      table_name: "arkflow_test"  
+
+    error_output:
+      type: "stdout"


### PR DESCRIPTION
## Description:
This PR introduces a brand‐new MySQL output plugin, using the native-tls-tls feature for SSL/TLS support. It currently covers:

## What’s included:
- mysql output plugin module
- Example mysql output plugin

## Next steps:
Once we’ve validated the approach and gathered feedback, I’ll extend the same pattern to implement output plugins for PostgreSQL, SQLite, and other supported databases.
#274 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new SQL output module supporting asynchronous data export to MySQL databases, including SSL support.
  - Added configuration options for SQL outputs, including MySQL connection details and SSL certificates.
  - Provided an example YAML configuration demonstrating how to use the new SQL output feature.

- **Chores**
  - Added required dependencies for MySQL support.
  - Updated the Docker image to install necessary database libraries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->