### PR TITLE
perf(processor/json): optimizes the conversion logic from JSON to Arrow

### DIFF
--- a/crates/arkflow-plugin/src/processor/json.rs
+++ b/crates/arkflow-plugin/src/processor/json.rs
@@ -51,7 +51,7 @@ impl Processor for JsonToArrowProcessor {
                 .unwrap_or(DEFAULT_BINARY_VALUE_FIELD),
         )?;
 
-        let json_data: Vec<u8> = result.join("\n".as_bytes());
+        let json_data: Vec<u8> = result.join(b"\n" as &[u8]);
         let record_batch = self.json_to_arrow(&json_data)?;
         Ok(vec![MessageBatch::new_arrow(record_batch)])
     }

--- a/crates/arkflow-plugin/src/processor/json.rs
+++ b/crates/arkflow-plugin/src/processor/json.rs
@@ -21,10 +21,6 @@ use arkflow_core::{Bytes, Error, MessageBatch, DEFAULT_BINARY_VALUE_FIELD};
 use arrow_json::ReaderBuilder;
 use async_trait::async_trait;
 use datafusion::arrow;
-use datafusion::arrow::array::{
-    ArrayRef, BooleanArray, Float64Array, Int64Array, NullArray, StringArray, UInt64Array,
-};
-use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::arrow::record_batch::RecordBatch;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -55,8 +51,8 @@ impl Processor for JsonToArrowProcessor {
                 .unwrap_or(DEFAULT_BINARY_VALUE_FIELD),
         )?;
 
-        let json_data: &[u8] = result.join("\n");
-        let record_batch = self.json_to_arrow(json_data)?;
+        let json_data: Vec<u8> = result.iter().flat_map(|x| x.iter().chain(b"\n")).copied().collect();
+        let record_batch = self.json_to_arrow(&json_data)?;
         Ok(vec![MessageBatch::new_arrow(record_batch)])
     }
 

--- a/crates/arkflow-plugin/src/processor/json.rs
+++ b/crates/arkflow-plugin/src/processor/json.rs
@@ -51,11 +51,7 @@ impl Processor for JsonToArrowProcessor {
                 .unwrap_or(DEFAULT_BINARY_VALUE_FIELD),
         )?;
 
-        let json_data: Vec<u8> = result
-            .iter()
-            .flat_map(|x| x.iter().chain(b"\n"))
-            .copied()
-            .collect();
+        let json_data: Vec<u8> = result.join("\n".as_bytes());
         let record_batch = self.json_to_arrow(&json_data)?;
         Ok(vec![MessageBatch::new_arrow(record_batch)])
     }
@@ -88,7 +84,7 @@ impl JsonToArrowProcessor {
         decoder
             .decode(content)
             .map_err(|e| Error::Process(format!("Arrow JSON Reader Error: {}", e)))?;
-        let mut batch = decoder
+        let batch = decoder
             .flush()
             .map_err(|e| Error::Process(format!("Arrow JSON Reader Flush Error: {}", e)))?
             .unwrap_or(RecordBatch::new_empty(inferred_schema));

--- a/crates/arkflow-plugin/src/processor/json.rs
+++ b/crates/arkflow-plugin/src/processor/json.rs
@@ -18,6 +18,7 @@
 
 use arkflow_core::processor::{register_processor_builder, Processor, ProcessorBuilder};
 use arkflow_core::{Bytes, Error, MessageBatch, DEFAULT_BINARY_VALUE_FIELD};
+use arrow_json::ReaderBuilder;
 use async_trait::async_trait;
 use datafusion::arrow;
 use datafusion::arrow::array::{
@@ -28,6 +29,7 @@ use datafusion::arrow::record_batch::RecordBatch;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashSet;
+use std::io::Cursor;
 use std::sync::Arc;
 
 /// Arrow format conversion processor configuration
@@ -46,26 +48,16 @@ pub struct JsonToArrowProcessor {
 #[async_trait]
 impl Processor for JsonToArrowProcessor {
     async fn process(&self, msg_batch: MessageBatch) -> Result<Vec<MessageBatch>, Error> {
-        let mut batches = Vec::with_capacity(msg_batch.len());
         let result = msg_batch.to_binary(
             self.config
                 .value_field
                 .as_deref()
                 .unwrap_or(DEFAULT_BINARY_VALUE_FIELD),
         )?;
-        for x in result {
-            let record_batch = self.json_to_arrow(x)?;
-            batches.push(record_batch)
-        }
 
-        if batches.is_empty() {
-            return Ok(vec![]);
-        }
-
-        let schema = batches[0].schema();
-        let batch = arrow::compute::concat_batches(&schema, &batches)
-            .map_err(|e| Error::Process(format!("Merge batches failed: {}", e)))?;
-        Ok(vec![MessageBatch::new_arrow(batch)])
+        let json_data: &[u8] = result.join("\n");
+        let record_batch = self.json_to_arrow(json_data)?;
+        Ok(vec![MessageBatch::new_arrow(record_batch)])
     }
 
     async fn close(&self) -> Result<(), Error> {
@@ -75,9 +67,22 @@ impl Processor for JsonToArrowProcessor {
 
 impl JsonToArrowProcessor {
     fn json_to_arrow(&self, content: &[u8]) -> Result<RecordBatch, Error> {
-        let json_value: Value = serde_json::from_slice(content)
-            .map_err(|e| Error::Process(format!("JSON parsing error: {}", e)))?;
-        json_to_arrow_inner(json_value, self.config.fields_to_include.as_ref())
+        let mut cursor_for_inference = Cursor::new(content);
+        let (inferred_schema, _) =
+            arrow_json::reader::infer_json_schema(&mut cursor_for_inference, Some(1))
+                .map_err(|e| Error::Process(format!("Schema inference error: {}", e)))?;
+        let inferred_schema = Arc::new(inferred_schema);
+
+        let mut decoder = ReaderBuilder::new(inferred_schema.clone())
+            .build_decoder()
+            .map_err(|e| Error::Process(format!("Arrow JSON Reader Builder Error: {}", e)))?;
+        decoder
+            .decode(content)
+            .map_err(|e| Error::Process(format!("Arrow JSON Reader Error: {}", e)))?;
+        Ok(decoder
+            .flush()
+            .map_err(|e| Error::Process(format!("Arrow JSON Reader Flush Error: {}", e)))?
+            .unwrap_or(RecordBatch::new_empty(inferred_schema)))
     }
 }
 
@@ -151,79 +156,6 @@ pub fn init() -> Result<(), Error> {
     register_processor_builder("arrow_to_json", Arc::new(ArrowToJsonProcessorBuilder))?;
     register_processor_builder("json_to_arrow", Arc::new(JsonToArrowProcessorBuilder))?;
     Ok(())
-}
-
-pub(crate) fn json_to_arrow_inner(
-    json_value: Value,
-    fields_to_include: Option<&HashSet<String>>,
-) -> Result<RecordBatch, Error> {
-    match json_value {
-        Value::Object(obj) => {
-            let mut fields = Vec::new();
-            let mut columns: Vec<ArrayRef> = Vec::new();
-
-            for (key, value) in obj {
-                if let Some(ref set) = fields_to_include {
-                    if !set.contains(&key) {
-                        continue;
-                    }
-                }
-                match value {
-                    Value::Null => {
-                        fields.push(Field::new(&key, DataType::Null, true));
-                        // 空值列处理
-                        columns.push(Arc::new(NullArray::new(1)));
-                    }
-                    Value::Bool(v) => {
-                        fields.push(Field::new(&key, DataType::Boolean, false));
-                        columns.push(Arc::new(BooleanArray::from(vec![v])));
-                    }
-                    Value::Number(v) => {
-                        if v.is_i64() {
-                            fields.push(Field::new(&key, DataType::Int64, false));
-                            columns.push(Arc::new(Int64Array::from(vec![v.as_i64().unwrap()])));
-                        } else if v.is_u64() {
-                            fields.push(Field::new(&key, DataType::UInt64, false));
-                            columns.push(Arc::new(UInt64Array::from(vec![v.as_u64().unwrap()])));
-                        } else {
-                            fields.push(Field::new(&key, DataType::Float64, false));
-                            columns.push(Arc::new(Float64Array::from(vec![v
-                                .as_f64()
-                                .unwrap_or(0.0)])));
-                        }
-                    }
-                    Value::String(v) => {
-                        fields.push(Field::new(&key, DataType::Utf8, false));
-                        columns.push(Arc::new(StringArray::from(vec![v])));
-                    }
-                    Value::Array(v) => {
-                        fields.push(Field::new(&key, DataType::Utf8, false));
-                        if let Ok(x) = serde_json::to_string(&v) {
-                            columns.push(Arc::new(StringArray::from(vec![x])));
-                        } else {
-                            columns.push(Arc::new(StringArray::from(vec!["[]".to_string()])));
-                        }
-                    }
-                    Value::Object(v) => {
-                        fields.push(Field::new(&key, DataType::Utf8, false));
-                        if let Ok(x) = serde_json::to_string(&v) {
-                            columns.push(Arc::new(StringArray::from(vec![x])));
-                        } else {
-                            columns.push(Arc::new(StringArray::from(vec!["{}".to_string()])));
-                        }
-                    }
-                };
-            }
-
-            let schema = Arc::new(Schema::new(fields));
-            RecordBatch::try_new(schema, columns).map_err(|e| {
-                Error::Process(format!("Creating an Arrow record batch failed: {}", e))
-            })
-        }
-        _ => Err(Error::Process(
-            "The input must be a JSON object".to_string(),
-        )),
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Use arrow_json libraries to refactor json_to_arrow methods to simplify code and improve maintainability. Remove redundant json_to_arrow_inner functions and use arrow_json ReaderBuilder for JSON parsing and Arrow RecordBatch generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified JSON to Arrow conversion by using Arrow's built-in JSON reader and schema inference.
  - Streamlined batch processing by merging all JSON inputs before conversion.
  - Removed custom, manual JSON-to-Arrow conversion logic for improved reliability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->