### PR TITLE
refactor: Change public structures and methods to private

### DIFF
--- a/crates/arkflow-core/src/stream/mod.rs
+++ b/crates/arkflow-core/src/stream/mod.rs
@@ -213,6 +213,7 @@ impl Stream {
                 }
             }
         }
+
         if let Err(e) = buffer.flush().await {
             error!("Failed to flush buffer: {}", e);
         }

--- a/crates/arkflow-plugin/src/buffer/memory.rs
+++ b/crates/arkflow-plugin/src/buffer/memory.rs
@@ -12,6 +12,12 @@
  *    limitations under the License.
  */
 
+//! Memory Buffer Implementation
+//!
+//! This module implements a memory-based buffer that accumulates messages until
+//! either a capacity threshold is reached or a timeout occurs. When either condition
+//! is met, the buffer releases all accumulated messages as a single batch.
+
 use crate::time::deserialize_duration;
 use arkflow_core::buffer::{register_buffer_builder, Buffer, BufferBuilder};
 use arkflow_core::input::Ack;
@@ -28,23 +34,37 @@ use tokio::sync::{Notify, RwLock};
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 
+/// Configuration for the memory buffer
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct MemoryBufferConfig {
-    /// Buffer capacity
+    /// Maximum number of messages to accumulate before releasing
     capacity: u32,
-    /// Buffer timeout
+    /// Maximum time to wait before releasing accumulated messages
     #[serde(deserialize_with = "deserialize_duration")]
     timeout: time::Duration,
 }
 
+/// Memory buffer implementation
+/// Accumulates messages in memory until capacity or timeout conditions are met
 struct MemoryBuffer {
+    /// Configuration parameters for the memory buffer
     config: MemoryBufferConfig,
+    /// Thread-safe queue to store message batches and their acknowledgments
     queue: Arc<RwLock<VecDeque<(MessageBatch, Arc<dyn Ack>)>>>,
+    /// Notification mechanism for signaling between threads
     notify: Arc<Notify>,
+    /// Token for cancellation of background tasks
     close: CancellationToken,
 }
 
 impl MemoryBuffer {
+    /// Creates a new memory buffer with the given configuration
+    ///
+    /// # Arguments
+    /// * `config` - Configuration parameters for the memory buffer
+    ///
+    /// # Returns
+    /// * `Result<Self, Error>` - A new memory buffer instance or an error
     fn new(config: MemoryBufferConfig) -> Result<Self, Error> {
         let notify = Arc::new(Notify::new());
         let notify_clone = Arc::clone(&notify);
@@ -78,6 +98,11 @@ impl MemoryBuffer {
         })
     }
 
+    /// Processes accumulated messages by merging them into a single batch
+    ///
+    /// # Returns
+    /// * `Result<Option<(MessageBatch, Arc<dyn Ack>)>, Error>` - The merged message batch and combined acknowledgment,
+    ///   or None if the queue is empty
     async fn process_messages(&self) -> Result<Option<(MessageBatch, Arc<dyn Ack>)>, Error> {
         let queue_arc = Arc::clone(&self.queue);
         let mut queue_lock = queue_arc.write().await;
@@ -109,15 +134,27 @@ impl MemoryBuffer {
 
 #[async_trait]
 impl Buffer for MemoryBuffer {
+    /// Writes a message batch to the memory buffer
+    ///
+    /// # Arguments
+    /// * `msg` - The message batch to write
+    /// * `arc` - The acknowledgment for the message batch
+    ///
+    /// # Returns
+    /// * `Result<(), Error>` - Success or an error
     async fn write(&self, msg: MessageBatch, arc: Arc<dyn Ack>) -> Result<(), Error> {
         let queue_arc = Arc::clone(&self.queue);
 
         let mut queue_lock = queue_arc.write().await;
         queue_lock.push_front((msg, arc));
+
+        // Calculate the total number of messages in the buffer
         let cnt = queue_lock.iter().map(|x| x.0.len()).reduce(|acc, x| {
             return acc + x;
         });
         let cnt = cnt.unwrap_or(0);
+
+        // If capacity threshold is reached, notify readers to process the batch
         if cnt >= self.config.capacity as usize {
             let notify = self.notify.clone();
             notify.notify_waiters();
@@ -125,44 +162,67 @@ impl Buffer for MemoryBuffer {
         Ok(())
     }
 
+    /// Reads a message batch from the memory buffer
+    /// Waits until either messages are available or the buffer is closed
+    ///
+    /// # Returns
+    /// * `Result<Option<(MessageBatch, Arc<dyn Ack>)>, Error>` - The merged message batch and combined acknowledgment,
+    ///   or None if the buffer is closed and empty
     async fn read(&self) -> Result<Option<(MessageBatch, Arc<dyn Ack>)>, Error> {
         loop {
             {
                 let queue_arc = Arc::clone(&self.queue);
                 let queue_lock = queue_arc.read().await;
+                // If there are messages available, break the loop and process them
                 if !queue_lock.is_empty() {
                     break;
                 }
+                // If the buffer is closed, return None
                 if self.close.is_cancelled() {
                     return Ok(None);
                 }
             }
+            // Wait for notification from timer, write operation, or close
             let notify = Arc::clone(&self.notify);
             notify.notified().await;
         }
+        // Process and return the accumulated messages
         self.process_messages().await
     }
 
+    /// Flushes the buffer by cancelling the background task and notifying waiters
+    ///
+    /// # Returns
+    /// * `Result<(), Error>` - Success or an error
     async fn flush(&self) -> Result<(), Error> {
         self.close.cancel();
 
         let queue_arc = Arc::clone(&self.queue);
         let queue_lock = queue_arc.read().await;
         if !queue_lock.is_empty() {
+            // Notify any waiting readers to process remaining messages
             let notify = Arc::clone(&self.notify);
             notify.notify_waiters();
         }
         Ok(())
     }
 
+    /// Closes the buffer by cancelling the background task
+    ///
+    /// # Returns
+    /// * `Result<(), Error>` - Success or an error
     async fn close(&self) -> Result<(), Error> {
         self.close.cancel();
         Ok(())
     }
 }
+/// Acknowledgment implementation that combines multiple acknowledgments
+/// When acknowledged, it acknowledges all contained acknowledgments
 struct ArrayAck(Vec<Arc<dyn Ack>>);
+
 #[async_trait]
 impl Ack for ArrayAck {
+    /// Acknowledges all contained acknowledgments
     async fn ack(&self) {
         for ack in self.0.iter() {
             ack.ack().await;
@@ -173,6 +233,13 @@ impl Ack for ArrayAck {
 struct MemoryBufferBuilder;
 
 impl BufferBuilder for MemoryBufferBuilder {
+    /// Builds a memory buffer from the provided configuration
+    ///
+    /// # Arguments
+    /// * `config` - JSON configuration for the memory buffer
+    ///
+    /// # Returns
+    /// * `Result<Arc<dyn Buffer>, Error>` - A new memory buffer instance or an error
     fn build(&self, config: &Option<Value>) -> Result<Arc<dyn Buffer>, Error> {
         if config.is_none() {
             return Err(Error::Config(
@@ -185,6 +252,10 @@ impl BufferBuilder for MemoryBufferBuilder {
     }
 }
 
+/// Initializes the memory buffer by registering its builder
+///
+/// # Returns
+/// * `Result<(), Error>` - Success or an error
 pub fn init() -> Result<(), Error> {
     register_buffer_builder("memory", Arc::new(MemoryBufferBuilder))
 }

--- a/crates/arkflow-plugin/src/buffer/memory.rs
+++ b/crates/arkflow-plugin/src/buffer/memory.rs
@@ -29,13 +29,15 @@ use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MemoryBufferConfig {
+struct MemoryBufferConfig {
+    /// Buffer capacity
     capacity: u32,
+    /// Buffer timeout
     #[serde(deserialize_with = "deserialize_duration")]
     timeout: time::Duration,
 }
 
-pub struct MemoryBuffer {
+struct MemoryBuffer {
     config: MemoryBufferConfig,
     queue: Arc<RwLock<VecDeque<(MessageBatch, Arc<dyn Ack>)>>>,
     notify: Arc<Notify>,

--- a/crates/arkflow-plugin/src/buffer/session_window.rs
+++ b/crates/arkflow-plugin/src/buffer/session_window.rs
@@ -29,12 +29,12 @@ use tokio::time::{sleep, Instant};
 use tokio_util::sync::CancellationToken;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SessionWindowConfig {
+struct SessionWindowConfig {
     #[serde(deserialize_with = "deserialize_duration")]
     gap: time::Duration,
 }
 
-pub struct SessionWindow {
+struct SessionWindow {
     config: SessionWindowConfig,
     queue: Arc<RwLock<VecDeque<(MessageBatch, Arc<dyn Ack>)>>>,
     notify: Arc<Notify>,

--- a/crates/arkflow-plugin/src/buffer/session_window.rs
+++ b/crates/arkflow-plugin/src/buffer/session_window.rs
@@ -12,6 +12,13 @@
  *    limitations under the License.
  */
 
+//! Session Window Buffer Implementation
+//!
+//! This module implements a session window buffer that groups messages into sessions
+//! based on a configurable gap duration. Messages are considered part of the same session
+//! if they arrive within the gap duration of each other. When the gap duration elapses
+//! without new messages, the session is closed and all accumulated messages are emitted.
+
 use crate::time::deserialize_duration;
 use arkflow_core::buffer::{register_buffer_builder, Buffer, BufferBuilder};
 use arkflow_core::input::{Ack, VecAck};
@@ -28,21 +35,38 @@ use tokio::sync::{Notify, RwLock};
 use tokio::time::{sleep, Instant};
 use tokio_util::sync::CancellationToken;
 
+/// Configuration for the session window buffer
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct SessionWindowConfig {
+    /// The maximum time gap between messages in a session
+    /// If no new messages arrive within this duration, the session is considered complete
     #[serde(deserialize_with = "deserialize_duration")]
     gap: time::Duration,
 }
 
+/// Session window buffer implementation
+/// Groups messages into sessions based on timing gaps between messages
 struct SessionWindow {
+    /// Configuration parameters for the session window
     config: SessionWindowConfig,
+    /// Thread-safe queue to store message batches and their acknowledgments
     queue: Arc<RwLock<VecDeque<(MessageBatch, Arc<dyn Ack>)>>>,
+    /// Notification mechanism for signaling between threads
     notify: Arc<Notify>,
+    /// Token for cancellation of background tasks
     close: CancellationToken,
+    /// Timestamp of the last received message, used to determine session boundaries
     last_message_time: Arc<RwLock<Instant>>,
 }
 
 impl SessionWindow {
+    /// Creates a new session window buffer with the given configuration
+    ///
+    /// # Arguments
+    /// * `config` - Configuration parameters for the session window
+    ///
+    /// # Returns
+    /// * `Result<Self, Error>` - A new session window instance or an error
     fn new(config: SessionWindowConfig) -> Result<Self, Error> {
         let notify = Arc::new(Notify::new());
         let notify_clone = Arc::clone(&notify);
@@ -80,6 +104,11 @@ impl SessionWindow {
         })
     }
 
+    /// Processes the current session by merging all accumulated messages
+    ///
+    /// # Returns
+    /// * `Result<Option<(MessageBatch, Arc<dyn Ack>)>, Error>` - The merged message batch and combined acknowledgment,
+    ///   or None if the queue is empty
     async fn process_session(&self) -> Result<Option<(MessageBatch, Arc<dyn Ack>)>, Error> {
         let mut queue_lock = self.queue.write().await;
         if queue_lock.is_empty() {
@@ -116,13 +145,28 @@ impl SessionWindow {
 
 #[async_trait]
 impl Buffer for SessionWindow {
+    /// Writes a message batch to the session window buffer
+    ///
+    /// # Arguments
+    /// * `msg` - The message batch to write
+    /// * `ack` - The acknowledgment for the message batch
+    ///
+    /// # Returns
+    /// * `Result<(), Error>` - Success or an error
     async fn write(&self, msg: MessageBatch, ack: Arc<dyn Ack>) -> Result<(), Error> {
         let mut queue_lock = self.queue.write().await;
         queue_lock.push_front((msg, ack));
+        // Update the last message timestamp to track session activity
         *self.last_message_time.write().await = Instant::now();
         Ok(())
     }
 
+    /// Reads a message batch from the session window buffer
+    /// Waits until either the session gap has elapsed or the buffer is closed
+    ///
+    /// # Returns
+    /// * `Result<Option<(MessageBatch, Arc<dyn Ack>)>, Error>` - The merged message batch and combined acknowledgment,
+    ///   or None if the buffer is closed and empty
     async fn read(&self) -> Result<Option<(MessageBatch, Arc<dyn Ack>)>, Error> {
         loop {
             {
@@ -130,6 +174,7 @@ impl Buffer for SessionWindow {
                 let queue_lock = queue_arc.read().await;
                 if !queue_lock.is_empty() {
                     let last_time = *self.last_message_time.read().await;
+                    // Check if the session gap has elapsed since the last message
                     if last_time.elapsed() >= self.config.gap {
                         break;
                     }
@@ -138,23 +183,34 @@ impl Buffer for SessionWindow {
                 }
             }
 
+            // Wait for notification from timer or write operation
             let notify = Arc::clone(&self.notify);
             notify.notified().await;
         }
+        // Process and return the current session
         self.process_session().await
     }
 
+    /// Flushes the buffer by cancelling the background task and notifying waiters
+    ///
+    /// # Returns
+    /// * `Result<(), Error>` - Success or an error
     async fn flush(&self) -> Result<(), Error> {
         self.close.cancel();
         let queue_arc = Arc::clone(&self.queue);
         let queue_lock = queue_arc.read().await;
         if !queue_lock.is_empty() {
+            // Notify any waiting readers to process remaining messages
             let notify = Arc::clone(&self.notify);
             notify.notify_waiters();
         }
         Ok(())
     }
 
+    /// Closes the buffer by cancelling the background task
+    ///
+    /// # Returns
+    /// * `Result<(), Error>` - Success or an error
     async fn close(&self) -> Result<(), Error> {
         self.close.cancel();
         Ok(())
@@ -164,6 +220,13 @@ impl Buffer for SessionWindow {
 struct SessionWindowBuilder;
 
 impl BufferBuilder for SessionWindowBuilder {
+    /// Builds a session window buffer from the provided configuration
+    ///
+    /// # Arguments
+    /// * `config` - JSON configuration for the session window
+    ///
+    /// # Returns
+    /// * `Result<Arc<dyn Buffer>, Error>` - A new session window buffer instance or an error
     fn build(&self, config: &Option<Value>) -> Result<Arc<dyn Buffer>, Error> {
         if config.is_none() {
             return Err(Error::Config(
@@ -176,6 +239,10 @@ impl BufferBuilder for SessionWindowBuilder {
     }
 }
 
+/// Initializes the session window buffer by registering its builder
+///
+/// # Returns
+/// * `Result<(), Error>` - Success or an error
 pub fn init() -> Result<(), Error> {
     register_buffer_builder("session_window", Arc::new(SessionWindowBuilder))
 }

--- a/crates/arkflow-plugin/src/buffer/sliding_window.rs
+++ b/crates/arkflow-plugin/src/buffer/sliding_window.rs
@@ -29,14 +29,17 @@ use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SlidingWindowConfig {
+struct SlidingWindowConfig {
+    /// Window size
     window_size: u32,
+    /// Interval between windows
     #[serde(deserialize_with = "deserialize_duration")]
     interval: time::Duration,
+    /// Slide size
     slide_size: u32,
 }
 
-pub struct SlidingWindow {
+struct SlidingWindow {
     config: SlidingWindowConfig,
     queue: Arc<RwLock<VecDeque<(MessageBatch, Arc<dyn Ack>)>>>,
     notify: Arc<Notify>,

--- a/crates/arkflow-plugin/src/buffer/sliding_window.rs
+++ b/crates/arkflow-plugin/src/buffer/sliding_window.rs
@@ -12,6 +12,13 @@
  *    limitations under the License.
  */
 
+//! Sliding Window Buffer Implementation
+//!
+//! This module implements a sliding window buffer that groups messages into overlapping
+//! time windows. Each window has a fixed size, and windows slide forward by a configurable
+//! number of messages after each window is emitted. This allows messages to be part of
+//! multiple windows, providing a more continuous view of the data stream.
+
 use crate::time::deserialize_duration;
 use arkflow_core::buffer::{register_buffer_builder, Buffer, BufferBuilder};
 use arkflow_core::input::{Ack, VecAck};
@@ -28,25 +35,40 @@ use tokio::sync::{Notify, RwLock};
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 
+/// Configuration for the sliding window buffer
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct SlidingWindowConfig {
-    /// Window size
+    /// The number of messages to include in each window
     window_size: u32,
-    /// Interval between windows
+    /// The time interval between window emissions
     #[serde(deserialize_with = "deserialize_duration")]
     interval: time::Duration,
-    /// Slide size
+    /// The number of messages to slide forward after each window emission
+    /// This determines the overlap between consecutive windows
     slide_size: u32,
 }
 
+/// Sliding window buffer implementation
+/// Groups messages into overlapping windows that slide forward over time
 struct SlidingWindow {
+    /// Configuration parameters for the sliding window
     config: SlidingWindowConfig,
+    /// Thread-safe queue to store message batches and their acknowledgments
     queue: Arc<RwLock<VecDeque<(MessageBatch, Arc<dyn Ack>)>>>,
+    /// Notification mechanism for signaling between threads
     notify: Arc<Notify>,
+    /// Token for cancellation of background tasks
     close: CancellationToken,
 }
 
 impl SlidingWindow {
+    /// Creates a new sliding window buffer with the given configuration
+    ///
+    /// # Arguments
+    /// * `config` - Configuration parameters for the sliding window
+    ///
+    /// # Returns
+    /// * `Result<Self, Error>` - A new sliding window instance or an error
     fn new(config: SlidingWindowConfig) -> Result<Self, Error> {
         let notify = Arc::new(Notify::new());
         let notify_clone = Arc::clone(&notify);
@@ -82,6 +104,11 @@ impl SlidingWindow {
         })
     }
 
+    /// Processes the current window by merging messages and sliding forward
+    ///
+    /// # Returns
+    /// * `Result<Option<(MessageBatch, Arc<dyn Ack>)>, Error>` - The merged message batch and combined acknowledgment,
+    ///   or None if there aren't enough messages to form a window
     async fn process_slide(&self) -> Result<Option<(MessageBatch, Arc<dyn Ack>)>, Error> {
         let mut queue_lock = self.queue.write().await;
         if queue_lock.len() < self.config.window_size as usize {
@@ -113,7 +140,8 @@ impl SlidingWindow {
 
         let new_ack = Arc::new(VecAck(acks));
 
-        // Remove slide_size messages from front
+        // Remove slide_size messages from the front of the queue
+        // This slides the window forward by the configured amount
         for _ in 0..self.config.slide_size {
             if queue_lock.pop_front().is_none() {
                 break;
@@ -126,41 +154,68 @@ impl SlidingWindow {
 
 #[async_trait]
 impl Buffer for SlidingWindow {
+    /// Writes a message batch to the sliding window buffer
+    ///
+    /// # Arguments
+    /// * `msg` - The message batch to write
+    /// * `ack` - The acknowledgment for the message batch
+    ///
+    /// # Returns
+    /// * `Result<(), Error>` - Success or an error
     async fn write(&self, msg: MessageBatch, ack: Arc<dyn Ack>) -> Result<(), Error> {
         let mut queue_lock = self.queue.write().await;
         queue_lock.push_back((msg, ack));
         Ok(())
     }
 
+    /// Reads a message batch from the sliding window buffer
+    /// Waits until either enough messages are available to form a window or the buffer is closed
+    ///
+    /// # Returns
+    /// * `Result<Option<(MessageBatch, Arc<dyn Ack>)>, Error>` - The merged message batch and combined acknowledgment,
+    ///   or None if the buffer is closed and empty
     async fn read(&self) -> Result<Option<(MessageBatch, Arc<dyn Ack>)>, Error> {
         loop {
             {
                 let queue_arc = Arc::clone(&self.queue);
                 let queue_lock = queue_arc.read().await;
+                // If there are enough messages to form a window, break the loop and process them
                 if queue_lock.len() >= self.config.window_size as usize {
                     break;
                 }
+                // If the buffer is closed, return None
                 if self.close.is_cancelled() {
                     return Ok(None);
                 }
             }
+            // Wait for notification from timer, write operation, or close
             let notify = Arc::clone(&self.notify);
             notify.notified().await;
         }
+        // Process the current window and slide forward
         self.process_slide().await
     }
 
+    /// Flushes the buffer by cancelling the background task and notifying waiters
+    ///
+    /// # Returns
+    /// * `Result<(), Error>` - Success or an error
     async fn flush(&self) -> Result<(), Error> {
         self.close.cancel();
         let queue_arc = Arc::clone(&self.queue);
         let queue_lock = queue_arc.read().await;
         if !queue_lock.is_empty() {
+            // Notify any waiting readers to process remaining messages
             let notify = Arc::clone(&self.notify);
             notify.notify_waiters();
         }
         Ok(())
     }
 
+    /// Closes the buffer by cancelling the background task
+    ///
+    /// # Returns
+    /// * `Result<(), Error>` - Success or an error
     async fn close(&self) -> Result<(), Error> {
         self.close.cancel();
         Ok(())
@@ -170,6 +225,13 @@ impl Buffer for SlidingWindow {
 struct SlidingWindowBuilder;
 
 impl BufferBuilder for SlidingWindowBuilder {
+    /// Builds a sliding window buffer from the provided configuration
+    ///
+    /// # Arguments
+    /// * `config` - JSON configuration for the sliding window
+    ///
+    /// # Returns
+    /// * `Result<Arc<dyn Buffer>, Error>` - A new sliding window buffer instance or an error
     fn build(&self, config: &Option<Value>) -> Result<Arc<dyn Buffer>, Error> {
         if config.is_none() {
             return Err(Error::Config(
@@ -178,6 +240,7 @@ impl BufferBuilder for SlidingWindowBuilder {
         }
 
         let config: SlidingWindowConfig = serde_json::from_value(config.clone().unwrap())?;
+        // Validate configuration parameters
         if config.window_size == 0 {
             return Err(Error::Config(
                 "Sliding window window_size must be greater than 0".to_string(),
@@ -198,6 +261,10 @@ impl BufferBuilder for SlidingWindowBuilder {
     }
 }
 
+/// Initializes the sliding window buffer by registering its builder
+///
+/// # Returns
+/// * `Result<(), Error>` - Success or an error
 pub fn init() -> Result<(), Error> {
     register_buffer_builder("sliding_window", Arc::new(SlidingWindowBuilder))
 }

--- a/crates/arkflow-plugin/src/buffer/tumbling_window.rs
+++ b/crates/arkflow-plugin/src/buffer/tumbling_window.rs
@@ -28,13 +28,16 @@ use tokio::sync::{Notify, RwLock};
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 
+/// Tumbling Window Buffer
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TumblingWindowConfig {
+struct TumblingWindowConfig {
+    /// Window interval
     #[serde(deserialize_with = "deserialize_duration")]
     interval: time::Duration,
 }
 
-pub struct TumblingWindow {
+struct TumblingWindow {
     queue: Arc<RwLock<VecDeque<(MessageBatch, Arc<dyn Ack>)>>>,
     notify: Arc<Notify>,
     close: CancellationToken,

--- a/crates/arkflow-plugin/src/buffer/tumbling_window.rs
+++ b/crates/arkflow-plugin/src/buffer/tumbling_window.rs
@@ -12,6 +12,13 @@
  *    limitations under the License.
  */
 
+//! Tumbling Window Buffer Implementation
+//!
+//! This module implements a tumbling window buffer that groups messages into fixed-size,
+//! non-overlapping time windows. Each window has a fixed duration, and when the window
+//! period elapses, all accumulated messages are emitted as a single batch and a new
+//! window begins immediately.
+
 use crate::time::deserialize_duration;
 use arkflow_core::buffer::{register_buffer_builder, Buffer, BufferBuilder};
 use arkflow_core::input::{Ack, VecAck};
@@ -28,22 +35,34 @@ use tokio::sync::{Notify, RwLock};
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 
-/// Tumbling Window Buffer
-
+/// Configuration for the tumbling window buffer
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct TumblingWindowConfig {
-    /// Window interval
+    /// The fixed duration of each window period
+    /// When this interval elapses, all accumulated messages are emitted
     #[serde(deserialize_with = "deserialize_duration")]
     interval: time::Duration,
 }
 
+/// Tumbling window buffer implementation
+/// Groups messages into fixed-size, non-overlapping time windows
 struct TumblingWindow {
+    /// Thread-safe queue to store message batches and their acknowledgments
     queue: Arc<RwLock<VecDeque<(MessageBatch, Arc<dyn Ack>)>>>,
+    /// Notification mechanism for signaling between threads
     notify: Arc<Notify>,
+    /// Token for cancellation of background tasks
     close: CancellationToken,
 }
 
 impl TumblingWindow {
+    /// Creates a new tumbling window buffer with the given configuration
+    ///
+    /// # Arguments
+    /// * `config` - Configuration parameters for the tumbling window
+    ///
+    /// # Returns
+    /// * `Result<Self, Error>` - A new tumbling window instance or an error
     fn new(config: TumblingWindowConfig) -> Result<Self, Error> {
         let notify = Arc::new(Notify::new());
         let notify_clone = Arc::clone(&notify);
@@ -78,6 +97,11 @@ impl TumblingWindow {
         })
     }
 
+    /// Processes the current window by merging all accumulated messages
+    ///
+    /// # Returns
+    /// * `Result<Option<(MessageBatch, Arc<dyn Ack>)>, Error>` - The merged message batch and combined acknowledgment,
+    ///   or None if the queue is empty
     async fn process_window(&self) -> Result<Option<(MessageBatch, Arc<dyn Ack>)>, Error> {
         let mut queue_lock = self.queue.write().await;
         if queue_lock.is_empty() {
@@ -108,41 +132,68 @@ impl TumblingWindow {
 
 #[async_trait]
 impl Buffer for TumblingWindow {
+    /// Writes a message batch to the tumbling window buffer
+    ///
+    /// # Arguments
+    /// * `msg` - The message batch to write
+    /// * `ack` - The acknowledgment for the message batch
+    ///
+    /// # Returns
+    /// * `Result<(), Error>` - Success or an error
     async fn write(&self, msg: MessageBatch, ack: Arc<dyn Ack>) -> Result<(), Error> {
         let mut queue_lock = self.queue.write().await;
         queue_lock.push_front((msg, ack));
         Ok(())
     }
 
+    /// Reads a message batch from the tumbling window buffer
+    /// Waits until either messages are available or the buffer is closed
+    ///
+    /// # Returns
+    /// * `Result<Option<(MessageBatch, Arc<dyn Ack>)>, Error>` - The merged message batch and combined acknowledgment,
+    ///   or None if the buffer is closed and empty
     async fn read(&self) -> Result<Option<(MessageBatch, Arc<dyn Ack>)>, Error> {
         loop {
             {
                 let queue_arc = Arc::clone(&self.queue);
                 let queue_lock = queue_arc.read().await;
+                // If there are messages available, break the loop and process them
                 if !queue_lock.is_empty() {
                     break;
                 }
+                // If the buffer is closed, return None
                 if self.close.is_cancelled() {
                     return Ok(None);
                 }
             }
+            // Wait for notification from timer, write operation, or close
             let notify = Arc::clone(&self.notify);
             notify.notified().await;
         }
+        // Process and return the current window
         self.process_window().await
     }
 
+    /// Flushes the buffer by cancelling the background task and notifying waiters
+    ///
+    /// # Returns
+    /// * `Result<(), Error>` - Success or an error
     async fn flush(&self) -> Result<(), Error> {
         self.close.cancel();
         let queue_arc = Arc::clone(&self.queue);
         let queue_lock = queue_arc.read().await;
         if !queue_lock.is_empty() {
+            // Notify any waiting readers to process remaining messages
             let notify = Arc::clone(&self.notify);
             notify.notify_waiters();
         }
         Ok(())
     }
 
+    /// Closes the buffer by cancelling the background task
+    ///
+    /// # Returns
+    /// * `Result<(), Error>` - Success or an error
     async fn close(&self) -> Result<(), Error> {
         self.close.cancel();
         Ok(())
@@ -152,6 +203,13 @@ impl Buffer for TumblingWindow {
 struct TumblingWindowBuilder;
 
 impl BufferBuilder for TumblingWindowBuilder {
+    /// Builds a tumbling window buffer from the provided configuration
+    ///
+    /// # Arguments
+    /// * `config` - JSON configuration for the tumbling window
+    ///
+    /// # Returns
+    /// * `Result<Arc<dyn Buffer>, Error>` - A new tumbling window buffer instance or an error
     fn build(&self, config: &Option<Value>) -> Result<Arc<dyn Buffer>, Error> {
         if config.is_none() {
             return Err(Error::Config(
@@ -164,6 +222,10 @@ impl BufferBuilder for TumblingWindowBuilder {
     }
 }
 
+/// Initializes the tumbling window buffer by registering its builder
+///
+/// # Returns
+/// * `Result<(), Error>` - Success or an error
 pub fn init() -> Result<(), Error> {
     register_buffer_builder("tumbling_window", Arc::new(TumblingWindowBuilder))
 }

--- a/crates/arkflow-plugin/src/output/drop.rs
+++ b/crates/arkflow-plugin/src/output/drop.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 ///
 /// This component implements the `Output` trait but doesn't perform any actual
 /// output operations. All messages sent to this output are simply discarded.
-pub struct DropOutput;
+struct DropOutput;
 
 #[async_trait]
 impl Output for DropOutput {
@@ -43,7 +43,7 @@ impl Output for DropOutput {
     }
 }
 
-pub(crate) struct DropOutputBuilder;
+struct DropOutputBuilder;
 impl OutputBuilder for DropOutputBuilder {
     fn build(&self, _: &Option<serde_json::Value>) -> Result<Arc<dyn Output>, Error> {
         Ok(Arc::new(DropOutput))

--- a/crates/arkflow-plugin/src/output/http.rs
+++ b/crates/arkflow-plugin/src/output/http.rs
@@ -28,7 +28,7 @@ use tokio::sync::Mutex;
 
 /// Authentication type
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum AuthType {
+enum AuthType {
     /// Basic authentication
     Basic { username: String, password: String },
     /// Bearer token authentication
@@ -37,25 +37,25 @@ pub enum AuthType {
 
 /// HTTP output configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct HttpOutputConfig {
+struct HttpOutputConfig {
     /// Destination URL
-    pub url: String,
+    url: String,
     /// HTTP method
-    pub method: String,
+    method: String,
     /// Timeout Period (ms)
-    pub timeout_ms: u64,
+    timeout_ms: u64,
     /// Number of retries
-    pub retry_count: u32,
+    retry_count: u32,
     /// Request header
-    pub headers: Option<std::collections::HashMap<String, String>>,
+    headers: Option<std::collections::HashMap<String, String>>,
     /// Body type
-    pub body_field: Option<String>,
+    body_field: Option<String>,
     /// Authentication configuration
-    pub auth: Option<AuthType>,
+    auth: Option<AuthType>,
 }
 
 /// HTTP output component
-pub struct HttpOutput {
+struct HttpOutput {
     config: HttpOutputConfig,
     client: Arc<Mutex<Option<Client>>>,
     connected: AtomicBool,
@@ -64,7 +64,7 @@ pub struct HttpOutput {
 
 impl HttpOutput {
     /// Create a new HTTP output component
-    pub fn new(config: HttpOutputConfig) -> Result<Self, Error> {
+    fn new(config: HttpOutputConfig) -> Result<Self, Error> {
         let auth = config.auth.clone();
         Ok(Self {
             config,

--- a/crates/arkflow-plugin/src/output/kafka.rs
+++ b/crates/arkflow-plugin/src/output/kafka.rs
@@ -55,21 +55,21 @@ impl std::fmt::Display for CompressionType {
 
 /// Kafka output configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct KafkaOutputConfig {
+struct KafkaOutputConfig {
     /// List of Kafka server addresses
-    pub brokers: Vec<String>,
+    brokers: Vec<String>,
     /// Target topic
-    pub topic: Expr<String>,
+    topic: Expr<String>,
     /// Partition key (optional)
-    pub key: Option<Expr<String>>,
+    key: Option<Expr<String>>,
     /// Client ID
-    pub client_id: Option<String>,
+    client_id: Option<String>,
     /// Compression type
-    pub compression: Option<CompressionType>,
+    compression: Option<CompressionType>,
     /// Acknowledgment level (0=no acknowledgment, 1=leader acknowledgment, all=all replica acknowledgments)
-    pub acks: Option<String>,
+    acks: Option<String>,
     /// Value type
-    pub value_field: Option<String>,
+    value_field: Option<String>,
 }
 
 /// Kafka output component

--- a/crates/arkflow-plugin/src/output/mqtt.rs
+++ b/crates/arkflow-plugin/src/output/mqtt.rs
@@ -29,29 +29,29 @@ use tracing::info;
 
 /// MQTT output configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MqttOutputConfig {
+struct MqttOutputConfig {
     /// MQTT broker address
-    pub host: String,
+    host: String,
     /// MQTT broker port
-    pub port: u16,
+    port: u16,
     /// Client ID
-    pub client_id: String,
+    client_id: String,
     /// Username (optional)
-    pub username: Option<String>,
+    username: Option<String>,
     /// Password (optional)
-    pub password: Option<String>,
+    password: Option<String>,
     /// Published topics
-    pub topic: Expr<String>,
+    topic: Expr<String>,
     /// Quality of Service (0, 1, 2)
-    pub qos: Option<u8>,
+    qos: Option<u8>,
     /// Whether to use clean session
-    pub clean_session: Option<bool>,
+    clean_session: Option<bool>,
     /// Keep alive interval (seconds)
-    pub keep_alive: Option<u64>,
+    keep_alive: Option<u64>,
     /// Whether to retain the message
-    pub retain: Option<bool>,
+    retain: Option<bool>,
     /// Value type
-    pub value_field: Option<String>,
+    value_field: Option<String>,
 }
 
 /// MQTT output component
@@ -64,7 +64,7 @@ struct MqttOutput<T: MqttClient> {
 
 impl<T: MqttClient> MqttOutput<T> {
     /// Create a new MQTT output component
-    pub fn new(config: MqttOutputConfig) -> Result<Self, Error> {
+    fn new(config: MqttOutputConfig) -> Result<Self, Error> {
         Ok(Self {
             config,
             client: Arc::new(Mutex::new(None)),
@@ -195,7 +195,7 @@ impl<T: MqttClient> Output for MqttOutput<T> {
     }
 }
 
-pub(crate) struct MqttOutputBuilder;
+struct MqttOutputBuilder;
 impl OutputBuilder for MqttOutputBuilder {
     fn build(&self, config: &Option<serde_json::Value>) -> Result<Arc<dyn Output>, Error> {
         if config.is_none() {

--- a/crates/arkflow-plugin/src/output/nats.rs
+++ b/crates/arkflow-plugin/src/output/nats.rs
@@ -29,20 +29,20 @@ use tracing::error;
 
 /// NATS output configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NatsOutputConfig {
+struct NatsOutputConfig {
     /// NATS server URL
-    pub url: String,
+    url: String,
     /// NATS mode
-    pub mode: Mode,
+    mode: Mode,
     /// Authentication credentials (optional)
-    pub auth: Option<NatsAuth>,
+    auth: Option<NatsAuth>,
     /// Value field to use for message payload
-    pub value_field: Option<String>,
+    value_field: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
-pub enum Mode {
+enum Mode {
     /// Regular NATS mode
     Regular {
         /// NATS subject to publish to
@@ -57,7 +57,7 @@ pub enum Mode {
 
 /// NATS authentication configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NatsAuth {
+struct NatsAuth {
     /// Username (optional)
     pub username: Option<String>,
     /// Password (optional)
@@ -67,7 +67,7 @@ pub struct NatsAuth {
 }
 
 /// NATS output component
-pub struct NatsOutput {
+struct NatsOutput {
     config: NatsOutputConfig,
     client: Arc<RwLock<Option<Client>>>,
     js_stream: Arc<RwLock<Option<Context>>>,
@@ -75,7 +75,7 @@ pub struct NatsOutput {
 
 impl NatsOutput {
     /// Create a new NATS output component
-    pub fn new(config: NatsOutputConfig) -> Result<Self, Error> {
+    fn new(config: NatsOutputConfig) -> Result<Self, Error> {
         Ok(Self {
             config,
             client: Arc::new(RwLock::new(None)),
@@ -214,7 +214,8 @@ impl Output for NatsOutput {
     }
 }
 
-pub(crate) struct NatsOutputBuilder;
+struct NatsOutputBuilder;
+
 impl OutputBuilder for NatsOutputBuilder {
     fn build(&self, config: &Option<serde_json::Value>) -> Result<Arc<dyn Output>, Error> {
         if config.is_none() {

--- a/crates/arkflow-plugin/src/output/stdout.rs
+++ b/crates/arkflow-plugin/src/output/stdout.rs
@@ -28,7 +28,7 @@ use tokio::sync::Mutex;
 
 /// Standard output configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct StdoutOutputConfig {
+struct StdoutOutputConfig {
     /// Whether to add a line break after each message
     pub append_newline: Option<bool>,
 }
@@ -66,6 +66,7 @@ where
         Ok(())
     }
 }
+
 impl<T: StdWriter> StdoutOutput<T> {
     async fn arrow_stdout(&self, message_batch: MessageBatch) -> Result<(), Error> {
         let mut writer_std = self.writer.lock().await;
@@ -92,7 +93,8 @@ impl<T: StdWriter> StdoutOutput<T> {
     }
 }
 
-pub(crate) struct StdoutOutputBuilder;
+struct StdoutOutputBuilder;
+
 impl OutputBuilder for StdoutOutputBuilder {
     fn build(&self, config: &Option<serde_json::Value>) -> Result<Arc<dyn Output>, Error> {
         if config.is_none() {

--- a/crates/arkflow-plugin/src/processor/batch.rs
+++ b/crates/arkflow-plugin/src/processor/batch.rs
@@ -27,13 +27,11 @@ use tokio::sync::{Mutex, RwLock};
 
 /// Batch processor configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BatchProcessorConfig {
+struct BatchProcessorConfig {
     /// Batch size
-    pub count: usize,
+    count: usize,
     /// Batch timeout (ms)
-    pub timeout_ms: u64,
-    /// Batch data type
-    pub data_type: String,
+    timeout_ms: u64,
 }
 
 /// Batch Processor Components
@@ -45,7 +43,7 @@ pub struct BatchProcessor {
 
 impl BatchProcessor {
     /// Create a new batch processor component
-    pub fn new(config: BatchProcessorConfig) -> Result<Self, Error> {
+    fn new(config: BatchProcessorConfig) -> Result<Self, Error> {
         Ok(Self {
             config: config.clone(),
             batch: Arc::new(RwLock::new(Vec::with_capacity(config.count))),
@@ -119,7 +117,7 @@ impl Processor for BatchProcessor {
     }
 }
 
-pub(crate) struct BatchProcessorBuilder;
+struct BatchProcessorBuilder;
 impl ProcessorBuilder for BatchProcessorBuilder {
     fn build(&self, config: &Option<serde_json::Value>) -> Result<Arc<dyn Processor>, Error> {
         if config.is_none() {
@@ -147,7 +145,6 @@ mod tests {
         let processor = BatchProcessor::new(BatchProcessorConfig {
             count: 2,
             timeout_ms: 1000,
-            data_type: "arrow".to_string(),
         })
         .unwrap();
 
@@ -171,7 +168,6 @@ mod tests {
         let processor = BatchProcessor::new(BatchProcessorConfig {
             count: 5,
             timeout_ms: 100,
-            data_type: "arrow".to_string(),
         })
         .unwrap();
 
@@ -198,7 +194,6 @@ mod tests {
         let processor = BatchProcessor::new(BatchProcessorConfig {
             count: 2,
             timeout_ms: 1000,
-            data_type: "arrow".to_string(),
         })
         .unwrap();
 
@@ -211,7 +206,6 @@ mod tests {
         let processor = BatchProcessor::new(BatchProcessorConfig {
             count: 5,
             timeout_ms: 1000,
-            data_type: "arrow".to_string(),
         })
         .unwrap();
 

--- a/crates/arkflow-plugin/src/processor/json.rs
+++ b/crates/arkflow-plugin/src/processor/json.rs
@@ -33,11 +33,11 @@ use std::sync::Arc;
 /// Arrow Format Conversion Processor
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct JsonProcessorConfig {
-    pub value_field: Option<String>,
-    pub fields_to_include: Option<HashSet<String>>,
+    value_field: Option<String>,
+    fields_to_include: Option<HashSet<String>>,
 }
 
-pub struct JsonToArrowProcessor {
+struct JsonToArrowProcessor {
     config: JsonProcessorConfig,
 }
 
@@ -132,7 +132,8 @@ impl ArrowToJsonProcessor {
     }
 }
 
-pub(crate) struct JsonToArrowProcessorBuilder;
+struct JsonToArrowProcessorBuilder;
+
 impl ProcessorBuilder for JsonToArrowProcessorBuilder {
     fn build(&self, config: &Option<Value>) -> Result<Arc<dyn Processor>, Error> {
         if config.is_none() {
@@ -145,7 +146,8 @@ impl ProcessorBuilder for JsonToArrowProcessorBuilder {
         Ok(Arc::new(JsonToArrowProcessor { config }))
     }
 }
-pub(crate) struct ArrowToJsonProcessorBuilder;
+struct ArrowToJsonProcessorBuilder;
+
 impl ProcessorBuilder for ArrowToJsonProcessorBuilder {
     fn build(&self, config: &Option<Value>) -> Result<Arc<dyn Processor>, Error> {
         if config.is_none() {

--- a/crates/arkflow-plugin/src/processor/protobuf.rs
+++ b/crates/arkflow-plugin/src/processor/protobuf.rs
@@ -57,7 +57,7 @@ enum ToType {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct ArrowConfig {
-    pub value_field: Option<String>,
+    value_field: Option<String>,
 }
 /// Protobuf Format Conversion Processor
 struct ProtobufProcessor {
@@ -67,7 +67,7 @@ struct ProtobufProcessor {
 
 impl ProtobufProcessor {
     /// Create a new Protobuf format conversion processor
-    pub fn new(config: ProtobufProcessorConfig) -> Result<Self, Error> {
+    fn new(config: ProtobufProcessorConfig) -> Result<Self, Error> {
         // Check the file extension to see if it's a proto file or a binary descriptor file
         let file_descriptor_set = Self::parse_proto_file(&config)?;
 

--- a/crates/arkflow-plugin/src/processor/sql.rs
+++ b/crates/arkflow-plugin/src/processor/sql.rs
@@ -34,27 +34,27 @@ use std::sync::Arc;
 const DEFAULT_TABLE_NAME: &str = "flow";
 /// SQL processor configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SqlProcessorConfig {
+struct SqlProcessorConfig {
     /// SQL query statement
-    pub query: String,
+    query: String,
 
     /// Table name (used in SQL queries)
-    pub table_name: Option<String>,
+    table_name: Option<String>,
 
     /// Experimental: Ballista helps us perform distributed computing
     ballista: Option<crate::input::sql::BallistaConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BallistaConfig {
+struct BallistaConfig {
     /// Ballista server url
-    pub remote_url: String,
+    remote_url: String,
 }
 
 /// SQL processor component
-pub struct SqlProcessor {
+struct SqlProcessor {
     config: SqlProcessorConfig,
-    pub statement: Statement,
+    statement: Statement,
 }
 
 impl SqlProcessor {
@@ -161,7 +161,7 @@ impl Processor for SqlProcessor {
     }
 }
 
-pub(crate) struct SqlProcessorBuilder;
+struct SqlProcessorBuilder;
 impl ProcessorBuilder for SqlProcessorBuilder {
     fn build(&self, config: &Option<serde_json::Value>) -> Result<Arc<dyn Processor>, Error> {
         if config.is_none() {

--- a/crates/arkflow-plugin/src/processor/vrl.rs
+++ b/crates/arkflow-plugin/src/processor/vrl.rs
@@ -28,13 +28,12 @@ pub fn init() -> Result<(), Error> {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct VrlProcessorConfig {
-    pub statement: String,
+    statement: String,
 }
 
-pub struct VrlProcessor {
+struct VrlProcessor {
     #[allow(unused)]
     config: VrlProcessorConfig,
-
     program: Program,
 }
 
@@ -66,10 +65,7 @@ impl Processor for VrlProcessor {
                 }
             }
         }
-        // for x in output {
-        //     let batch = vrl_values_to_message_batch(x)?;
-        //     batch
-        // }
+
         output
             .into_iter()
             .map(|x| vrl_values_to_message_batch(x))
@@ -81,7 +77,7 @@ impl Processor for VrlProcessor {
     }
 }
 
-pub(crate) struct VrlProcessorBuilder;
+struct VrlProcessorBuilder;
 impl ProcessorBuilder for VrlProcessorBuilder {
     fn build(&self, config: &Option<Value>) -> Result<Arc<dyn Processor>, Error> {
         if config.is_none() {
@@ -102,7 +98,7 @@ impl ProcessorBuilder for VrlProcessorBuilder {
     }
 }
 
-pub(crate) fn message_batch_to_vrl_values(message_batch: MessageBatch) -> Vec<VrlValue> {
+fn message_batch_to_vrl_values(message_batch: MessageBatch) -> Vec<VrlValue> {
     let rows = message_batch.num_rows();
     let mut vrl_values: Vec<ObjectMap> = Vec::with_capacity(rows);
     for _ in 0..rows {
@@ -282,9 +278,7 @@ pub(crate) fn message_batch_to_vrl_values(message_batch: MessageBatch) -> Vec<Vr
     vrl_values.into_iter().map(|v| v.into()).collect()
 }
 
-pub(crate) fn vrl_values_to_message_batch(
-    mut vrl_values: Vec<VrlValue>,
-) -> Result<MessageBatch, Error> {
+fn vrl_values_to_message_batch(mut vrl_values: Vec<VrlValue>) -> Result<MessageBatch, Error> {
     if vrl_values.is_empty() {}
     let Some(first_value) = vrl_values.get(0) else {
         return Ok(MessageBatch::from(RecordBatch::new_empty(Arc::new(
@@ -414,13 +408,13 @@ pub(crate) fn vrl_values_to_message_batch(
     Ok(MessageBatch::new_arrow(result))
 }
 
-pub(crate) fn insert(i: usize, vrl_values: &mut Vec<ObjectMap>, name: &str, val: VrlValue) {
+fn insert(i: usize, vrl_values: &mut Vec<ObjectMap>, name: &str, val: VrlValue) {
     if let Some(obj) = vrl_values.get_mut(i) {
         obj.insert(name.to_string().into(), val);
     }
 }
 
-pub(crate) fn get_arrow_data_type(val: &VrlValue) -> Result<DataType, Error> {
+fn get_arrow_data_type(val: &VrlValue) -> Result<DataType, Error> {
     match val {
         VrlValue::Bytes(_) => Ok(DataType::Binary),
         VrlValue::Integer(_) => Ok(DataType::Int64),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Restricted access to configuration and builder components across multiple outputs and processors by limiting their visibility.
  - Removed public access to certain fields and constructors to encapsulate internal details.
  - Added extensive documentation comments to buffer components to improve clarity and maintainability.
  - Validated buffer configuration parameters for sliding window buffers.
  - Cleaned up commented-out code in the VRL processor.

No changes to user-facing functionality or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->