### PR TITLE
feat(input): Add support for Redis cluster mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2008,6 +2008,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc16"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5815,12 +5821,16 @@ dependencies = [
  "bytes",
  "cfg-if",
  "combine",
+ "crc16",
  "futures-channel",
+ "futures-sink",
  "futures-util",
  "itoa",
+ "log",
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
+ "rand 0.9.0",
  "ryu",
  "sha1_smol",
  "socket2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5827,6 +5827,7 @@ dependencies = [
  "futures-util",
  "itoa",
  "log",
+ "native-tls",
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
@@ -5835,6 +5836,7 @@ dependencies = [
  "sha1_smol",
  "socket2",
  "tokio",
+ "tokio-native-tls",
  "tokio-util",
  "url",
 ]

--- a/crates/arkflow-plugin/Cargo.toml
+++ b/crates/arkflow-plugin/Cargo.toml
@@ -58,7 +58,7 @@ rdkafka-sys = "4.8.0"
 sasl2-sys = { version = "0.1.22", features = ["vendored"] }
 
 # redis
-redis = { version = "0.31", features = ["tokio-comp", "aio","connection-manager"] }
+redis = { version = "0.31", features = ["tokio-comp", "aio", "connection-manager", "cluster-async"] }
 
 # vrl https://github.com/vectordotdev/vrl
 vrl = { version = "0.23.0", features = ["value", "compiler", "stdlib"] }
@@ -74,7 +74,7 @@ tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
 async-nats = "0.40.0"
 
 
-futures = {workspace = true}
+futures = { workspace = true }
 tokio-stream = "0.1.17"
 url = "2.5.4"
 

--- a/crates/arkflow-plugin/Cargo.toml
+++ b/crates/arkflow-plugin/Cargo.toml
@@ -58,7 +58,7 @@ rdkafka-sys = "4.8.0"
 sasl2-sys = { version = "0.1.22", features = ["vendored"] }
 
 # redis
-redis = { version = "0.31", features = ["tokio-comp", "aio", "connection-manager", "cluster-async"] }
+redis = { version = "0.31", features = ["tokio-native-tls-comp", "aio", "connection-manager", "cluster-async"] }
 
 # vrl https://github.com/vectordotdev/vrl
 vrl = { version = "0.23.0", features = ["value", "compiler", "stdlib"] }

--- a/crates/arkflow-plugin/src/input/redis.rs
+++ b/crates/arkflow-plugin/src/input/redis.rs
@@ -315,6 +315,7 @@ impl Input for RedisInput {
 
     async fn close(&self) -> Result<(), Error> {
         self.cancellation_token.cancel();
+        self.client.lock().await.take();
         Ok(())
     }
 }

--- a/crates/arkflow-plugin/src/input/redis.rs
+++ b/crates/arkflow-plugin/src/input/redis.rs
@@ -35,7 +35,6 @@ use tracing::{debug, error};
 /// Redis input configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RedisInputConfig {
-    /// Redis server URL
     mode: ModeConfig,
     redis_type: Type,
 }

--- a/crates/arkflow-plugin/src/input/redis.rs
+++ b/crates/arkflow-plugin/src/input/redis.rs
@@ -268,7 +268,9 @@ impl RedisInput {
                         tokio::select! {
                             Some(msg_result) = msg_stream.next() => {
                                 let channel: String = msg_result.get_channel_name().to_string();
-                                let payload: Vec<u8> = msg_result.get_payload().unwrap_or_default();
+                                let Ok(payload )=   msg_result.get_payload() else {
+                                       continue;
+                                };
                                 if let Err(e) = sender_clone.send_async(RedisMsg::Message(channel, payload)).await {
                                     error!("{}", e);
                                 }

--- a/examples/redis_input_example.yaml
+++ b/examples/redis_input_example.yaml
@@ -3,23 +3,25 @@ logging:
 streams:
   - input:
       type: "redis"
-      url: "redis://127.0.0.1:6379"
+      mode:
+        type: single
+        url: redis://127.0.0.1:6379
 
-#      redis_type:
-#        type: subscribe
-#        subscribe:
-#          type: channels
-#          channels: [ "test" ]
+      redis_type:
+        type: subscribe
+        subscribe:
+          type: channels
+          channels: [ "test" ]
 
 #      redis_type:
 #        type: subscribe
 #        subscribe:
 #          type: patterns
 #          patterns: [ "test" ]
-
-      redis_type:
-        type: list
-        list: [ "test" ]
+#
+#      redis_type:
+#        type: list
+#        list: [ "test" ]
 
     pipeline:
       thread_num: 4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for connecting to Redis clusters alongside single-node Redis instances.
  - Enabled subscription to Redis channels with enhanced configuration options.

- **Refactor**
  - Updated configuration to select between single-node and cluster connection modes for Redis inputs.
  - Improved Redis message handling with asynchronous processing for both connection modes.
  - Enhanced connection lifecycle management with graceful unsubscription on close.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->