### PR TITLE
perf(expr): Evaluate performance using once_cell and cache-optimized expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,7 @@ dependencies = [
  "humantime",
  "lazy_static",
  "mockall",
+ "once_cell",
  "prost-reflect",
  "prost-types",
  "protobuf",

--- a/crates/arkflow-plugin/Cargo.toml
+++ b/crates/arkflow-plugin/Cargo.toml
@@ -74,6 +74,8 @@ tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
 async-nats = "0.40.0"
 
 
+once_cell = "1.19.0"
+
 futures = { workspace = true }
 tokio-stream = "0.1.17"
 url = "2.5.4"

--- a/crates/arkflow-plugin/src/output/kafka.rs
+++ b/crates/arkflow-plugin/src/output/kafka.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use arkflow_core::output::{register_output_builder, Output, OutputBuilder};
 use arkflow_core::{Error, MessageBatch, DEFAULT_BINARY_VALUE_FIELD};
 
-use crate::expr::{EvaluateExpr, EvaluateResult, Expr};
+use crate::expr::{EvaluateResult, Expr};
 use async_trait::async_trait;
 use rdkafka::config::ClientConfig;
 use rdkafka::error::KafkaError;
@@ -189,8 +189,8 @@ impl Output for KafkaOutput {
             return Ok(());
         }
 
-        let topic = self.get_topic(&msg)?;
-        let key = self.get_key(&msg)?;
+        let topic = self.get_topic(&msg).await?;
+        let key = self.get_key(&msg).await?;
 
         // Prepare all records for sending
         for (i, x) in payloads.into_iter().enumerate() {
@@ -272,16 +272,16 @@ impl Output for KafkaOutput {
     }
 }
 impl KafkaOutput {
-    fn get_topic(&self, msg: &MessageBatch) -> Result<EvaluateResult<String>, Error> {
-        self.config.topic.evaluate_expr(msg)
+    async fn get_topic(&self, msg: &MessageBatch) -> Result<EvaluateResult<String>, Error> {
+        self.config.topic.evaluate_expr(msg).await
     }
 
-    fn get_key(&self, msg: &MessageBatch) -> Result<Option<EvaluateResult<String>>, Error> {
+    async fn get_key(&self, msg: &MessageBatch) -> Result<Option<EvaluateResult<String>>, Error> {
         let Some(v) = &self.config.key else {
             return Ok(None);
         };
 
-        Ok(Some(v.evaluate_expr(msg)?))
+        Ok(Some(v.evaluate_expr(msg).await?))
     }
 }
 

--- a/crates/arkflow-plugin/src/output/mqtt.rs
+++ b/crates/arkflow-plugin/src/output/mqtt.rs
@@ -16,7 +16,7 @@
 //!
 //! Send the processed data to the MQTT broker
 
-use crate::expr::{EvaluateExpr, Expr};
+use crate::expr::Expr;
 use arkflow_core::output::{register_output_builder, Output, OutputBuilder};
 use arkflow_core::{Error, MessageBatch, DEFAULT_BINARY_VALUE_FIELD};
 use async_trait::async_trait;
@@ -144,7 +144,7 @@ impl<T: MqttClient> Output for MqttOutput<T> {
             }
         };
 
-        let topic = self.config.topic.evaluate_expr(&msg)?;
+        let topic = self.config.topic.evaluate_expr(&msg).await?;
 
         // Determine the QoS level
         let qos_level = match self.config.qos {

--- a/crates/arkflow-plugin/src/output/nats.rs
+++ b/crates/arkflow-plugin/src/output/nats.rs
@@ -16,7 +16,7 @@
 //!
 //! Send data to a NATS subject
 
-use crate::expr::{EvaluateExpr, Expr};
+use crate::expr::Expr;
 use arkflow_core::output::{register_output_builder, Output, OutputBuilder};
 use arkflow_core::{Error, MessageBatch, DEFAULT_BINARY_VALUE_FIELD};
 use async_nats::jetstream::Context;
@@ -148,7 +148,7 @@ impl Output for NatsOutput {
         // Get subject
         let subject = match &self.config.mode {
             Mode::Regular { subject } | Mode::JetStream { subject } => {
-                subject.evaluate_expr(&msg)?
+                subject.evaluate_expr(&msg).await?
             }
         };
 

--- a/crates/arkflow-plugin/src/output/redis.rs
+++ b/crates/arkflow-plugin/src/output/redis.rs
@@ -11,7 +11,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-use crate::expr::{EvaluateExpr, Expr};
+use crate::expr::Expr;
 use arkflow_core::output::{Output, OutputBuilder};
 use arkflow_core::{Error, MessageBatch, DEFAULT_BINARY_VALUE_FIELD};
 use async_trait::async_trait;
@@ -142,7 +142,7 @@ impl Output for RedisOutput {
 
         match &self.config.redis_type {
             Type::Publish { channel } => {
-                let key_result = channel.evaluate_expr(&msg).map_err(|e| {
+                let key_result = channel.evaluate_expr(&msg).await.map_err(|e| {
                     Error::Process(format!("Failed to evaluate channel expression: {}", e))
                 })?;
 
@@ -165,7 +165,7 @@ impl Output for RedisOutput {
                 }
             }
             Type::List { key } => {
-                let key_result = key.evaluate_expr(&msg).map_err(|e| {
+                let key_result = key.evaluate_expr(&msg).await.map_err(|e| {
                     Error::Process(format!("Failed to evaluate key expression: {}", e))
                 })?;
 
@@ -188,11 +188,11 @@ impl Output for RedisOutput {
                 }
             }
             Type::Hashes { key, field } => {
-                let key_result = key.evaluate_expr(&msg).map_err(|e| {
+                let key_result = key.evaluate_expr(&msg).await.map_err(|e| {
                     Error::Process(format!("Failed to evaluate key expression: {}", e))
                 })?;
 
-                let field_result = field.evaluate_expr(&msg).map_err(|e| {
+                let field_result = field.evaluate_expr(&msg).await.map_err(|e| {
                     Error::Process(format!("Failed to evaluate field expression: {}", e))
                 })?;
 
@@ -224,7 +224,7 @@ impl Output for RedisOutput {
                 }
             }
             Type::Strings { key } => {
-                let key_result = key.evaluate_expr(&msg).map_err(|e| {
+                let key_result = key.evaluate_expr(&msg).await.map_err(|e| {
                     Error::Process(format!("Failed to evaluate key expression: {}", e))
                 })?;
                 for (x, payload) in data.into_iter().enumerate() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expression evaluation is now performed asynchronously across all output types, improving performance and scalability for Kafka, MQTT, NATS, and Redis outputs.

- **Refactor**
  - Updated internal logic to cache compiled expressions for more efficient repeated evaluations.
  - Simplified and unified expression evaluation APIs, removing deprecated traits and updating method signatures to use async/await.

- **Chores**
  - Updated dependencies to include the latest version of `once_cell`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->