### PR TITLE
feat: Add SQLite support and simplify SQL output configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4233,6 +4233,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ flume = "=0.11"
 rumqttc = "0.24.0"
 
 # Sql
-sqlx = { version = "0.8", features = [ "mysql","postgres","runtime-tokio", "tls-native-tls" ] }
+sqlx = { version = "0.8", features = [ "mysql","postgres","sqlite","runtime-tokio", "tls-native-tls" ] }
 
 # Kafka
 aws-msk-iam-sasl-signer = "1.0.0"

--- a/examples/sql_output_example.yaml
+++ b/examples/sql_output_example.yaml
@@ -16,10 +16,9 @@ streams:
 
     output:
       type: "sql"
-      output_type:
-        type: "mysql"
-        uri: "mysql://root:1234@localhost:3306/arkflow"
-        table_name: "arkflow_test"
+      database_type: "mysql"
+      uri: "mysql://root:1234@localhost:3306/arkflow"
+      table_name: "arkflow_test"
 
     error_output:
       type: "stdout"


### PR DESCRIPTION
This PR introduces the following changes:

- SQLite support has been added to the SQL output feature, enabling users to output data directly to SQLite databases.
- Refactored the SQL output YAML configuration to be more intuitive and user-friendly. The new format makes it easier to understand and configure SQL output settings.

```
output:
  type: "sql"
  database_type: "mysql"
  uri: "mysql://root:1234@localhost:3306/arkflow"
  table_name: "arkflow_test"
```
@chenquan Please take a look when you get a chance — your feedback would be appreciated!

#274 