### PR TITLE
feat(input/sql): Adds support for S3 object storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,7 @@ dependencies = [
  "humantime",
  "lazy_static",
  "mockall",
+ "object_store",
  "once_cell",
  "prost-reflect",
  "prost-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,7 +1837,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2987,7 +2987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5751,7 +5751,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6236,7 +6236,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6249,7 +6249,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7128,7 +7128,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7325,7 +7325,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8494,7 +8494,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/arkflow-plugin/Cargo.toml
+++ b/crates/arkflow-plugin/Cargo.toml
@@ -72,6 +72,7 @@ tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
 
 # NATS
 async-nats = "0.41.0"
+object_store= "0.11.2"
 
 
 once_cell = "1.19.0"

--- a/crates/arkflow-plugin/src/input/sql.rs
+++ b/crates/arkflow-plugin/src/input/sql.rs
@@ -423,6 +423,7 @@ impl SqlInput {
         .map_err(|e| Error::Process(format!("Registration input failed: {}", e)))
     }
 
+    /// Create a session context
     async fn create_session_context(&self) -> Result<SessionContext, Error> {
         let mut ctx = if let Some(ballista) = &self.sql_config.ballista {
             SessionContext::remote(&ballista.remote_url)
@@ -438,6 +439,7 @@ impl SqlInput {
         Ok(ctx)
     }
 
+    /// Create an object store
     async fn object_store(
         &self,
         ctx: &SessionContext,
@@ -447,6 +449,8 @@ impl SqlInput {
             ObjectStore::S3(aws_s3_config) => self.aws_s3_object_store(ctx, aws_s3_config).await,
         }
     }
+
+    /// Create an AWS S3 object store
     async fn aws_s3_object_store(
         &self,
         ctx: &SessionContext,

--- a/examples/sql_input_example.yaml
+++ b/examples/sql_input_example.yaml
@@ -5,20 +5,20 @@ streams:
       type: "sql"
       input_type:
         type: "json"
-  #      input_type: "csv"
+        #      input_type: "csv"
         path: './examples/stream_data.json'
         object_store:
           type: s3
-          endpoint: "https://s3.example.com"  # 可选
+          endpoint: "https://s3.example.com"
           region: "us-west-1"
           bucket_name: "my-bucket"
           access_key_id: "your-access-key"
           secret_access_key: "your-secret-key"
           allow_http: false
-  #      path: './examples/input_data.csv'
+      #      path: './examples/input_data.csv'
       select_sql: |
         select *,value + 999999 from flow;
-      
+    
     
 
     pipeline:

--- a/examples/sql_input_example.yaml
+++ b/examples/sql_input_example.yaml
@@ -7,10 +7,18 @@ streams:
         type: "json"
   #      input_type: "csv"
         path: './examples/stream_data.json'
+        object_store:
+          type: s3
+          endpoint: "https://s3.example.com"  # 可选
+          region: "us-west-1"
+          bucket_name: "my-bucket"
+          access_key_id: "your-access-key"
+          secret_access_key: "your-secret-key"
+          allow_http: false
   #      path: './examples/input_data.csv'
       select_sql: |
         select *,value + 999999 from flow;
-
+      
     
 
     pipeline:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Extended AWS S3 support to include Arrow, JSON, CSV, Parquet, and Avro file formats in the SQL input plugin.
  - Users can now configure S3 connection details to access multiple file types stored in S3 buckets seamlessly.
  - Added support for configuring object stores in SQL input streams, enabling data ingestion from S3-compatible storage for various file formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->