### PR TITLE
chore(docker): Update the Docker image to Rust version 1.86-slim

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM rust:1.85-slim as builder
+FROM rust:1.86-slim as builder
 
 WORKDIR /app
 COPY .. .


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Docker build process to use a newer version of the Rust base image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->