### PR TITLE
perf(buffer/join): Add multi-threaded support to improve batch processing performance

### DIFF
--- a/crates/arkflow-plugin/src/buffer/join.rs
+++ b/crates/arkflow-plugin/src/buffer/join.rs
@@ -138,18 +138,13 @@ impl JoinOperation {
         }
 
         let chunk_size = total_rows.div_ceil(size);
-        let mut chunks = Vec::new();
-
+        let mut chunks = Vec::with_capacity(size);
         let mut offset = 0;
         while offset < total_rows {
-            // 计算当前 chunk 的长度，确保不会超出总行数
             let length = std::cmp::min(chunk_size, total_rows - offset);
 
-            // 使用 slice() 方法创建切片，这是一个高效的零拷贝操作
             let slice = batch_to_split.slice(offset, length);
             chunks.push(slice);
-
-            // 更新下一次切片的起始位置
             offset += length;
         }
 

--- a/crates/arkflow-plugin/src/buffer/join.rs
+++ b/crates/arkflow-plugin/src/buffer/join.rs
@@ -31,7 +31,7 @@ pub(crate) struct JoinConfig {
     pub(crate) value_field: Option<String>,
     pub(crate) codec: CodecConfig,
     #[serde(default = "default_thread_num")]
-    pub(crate) thead_num: usize,
+    pub(crate) thread_num: usize,
 }
 
 pub(crate) struct JoinOperation {
@@ -39,21 +39,21 @@ pub(crate) struct JoinOperation {
     value_field: Option<String>,
     codec: Arc<dyn Decoder>,
     input_names: HashSet<String>,
-    thead_num: usize,
+    thread_num: usize,
 }
 
 impl JoinOperation {
     pub(crate) fn new(
         query: String,
         value_field: Option<String>,
-        thead_num: usize,
+        thread_num: usize,
         codec: Arc<dyn Decoder>,
         input_names: HashSet<String>,
     ) -> Result<Self, Error> {
         Ok(Self {
             query,
             value_field,
-            thead_num,
+            thread_num,
             codec,
             input_names,
         })
@@ -78,7 +78,7 @@ impl JoinOperation {
                 continue;
             };
 
-            let vec_rb = self.split_batch(&msg_batch, self.thead_num);
+            let vec_rb = self.split_batch(&msg_batch, self.thread_num);
             let mut batches = vec_rb.into_iter().peekable();
             let schema = if let Some(batch) = batches.peek() {
                 batch.schema()

--- a/crates/arkflow-plugin/src/buffer/join.rs
+++ b/crates/arkflow-plugin/src/buffer/join.rs
@@ -85,8 +85,8 @@ impl JoinOperation {
             } else {
                 Arc::new(Schema::empty())
             };
-
-            let provider = MemTable::try_new(schema, vec![batches.collect()])
+            let batches = batches.map(|b| vec![b]).collect::<Vec<_>>();
+            let provider = MemTable::try_new(schema, batches)
                 .map_err(|e| Error::Process(format!("Failed to create MemTable: {}", e)))?;
 
             ctx.register_table(

--- a/crates/arkflow-plugin/src/buffer/join.rs
+++ b/crates/arkflow-plugin/src/buffer/join.rs
@@ -132,6 +132,7 @@ impl JoinOperation {
     }
 
     fn split_batch(&self, batch_to_split: &RecordBatch, size: usize) -> Vec<RecordBatch> {
+        let size = size.max(1);
         let total_rows = batch_to_split.num_rows();
         if total_rows <= size {
             return vec![batch_to_split.clone()];

--- a/crates/arkflow-plugin/src/buffer/window.rs
+++ b/crates/arkflow-plugin/src/buffer/window.rs
@@ -74,7 +74,7 @@ impl BaseWindow {
                     .map(|name| name.clone())
                     .collect::<HashSet<String>>();
 
-                JoinOperation::new(config.query, config.value_field, codec, input_names)
+                JoinOperation::new(config.query, config.value_field,config.thead_num, codec, input_names)
             })
             .transpose()?;
 

--- a/crates/arkflow-plugin/src/buffer/window.rs
+++ b/crates/arkflow-plugin/src/buffer/window.rs
@@ -74,7 +74,13 @@ impl BaseWindow {
                     .map(|name| name.clone())
                     .collect::<HashSet<String>>();
 
-                JoinOperation::new(config.query, config.value_field,config.thead_num, codec, input_names)
+                JoinOperation::new(
+                    config.query,
+                    config.value_field,
+                    config.thread_num,
+                    codec,
+                    input_names,
+                )
             })
             .transpose()?;
 


### PR DESCRIPTION
Add thead_num parameter to JoinOperation to support multi-threaded processing, using CPU cores by default Implementing the split_match method to split a large RecordBatch into multiple small blocks for parallel processing Using MemTable as a substitute for registrant batch to improve registry performance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configuration option to control the number of partitions used when processing input data for join operations, allowing for improved performance and parallelism.
- **Improvements**
  - Enhanced data processing by splitting input batches into smaller chunks, enabling more efficient join operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->