### PR TITLE
chore: specify the minimum Rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["chenquan <chenquan.dev@gmail.com>"]
 repository = "https://github.com/arkflow-rs/arkflow"
 homepage = "https://github.com/arkflow-rs/arkflow"
 license = "Apache-2.0"
+rust-version = "1.88"
 
 [workspace]
 members = ["crates/arkflow-plugin", "crates/arkflow-core", "crates/arkflow"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Set the minimum Rust toolchain version to 1.88 for the workspace to ensure consistent, reproducible builds across environments.
  * Clarifies tooling requirements and prevents use of unsupported compilers, reducing build inconsistencies.
  * No changes to app behavior or UI; end users are unaffected.
  * Contributors and build pipelines may need to update their Rust toolchain to match the new requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->