### PR TITLE
chore(docker): Upgrade Rust base image to 1.88-slim

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM rust:1.86-slim as builder
+FROM rust:1.88-slim as builder
 
 WORKDIR /app
 COPY .. .


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build base image to rust:1.88-slim.
  * No changes to application behavior or commands; build and runtime steps remain the same.
  * A fresh base image will be fetched on the next build, which may invalidate previous layer caches.
  * Existing workflows continue to work; no configuration changes are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->